### PR TITLE
feat(#31): GetInventoryUseCase 구현

### DIFF
--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/GetInventoryQuery.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/GetInventoryQuery.java
@@ -1,0 +1,17 @@
+package com.commerce.inventory.application.port.in;
+
+import jakarta.validation.constraints.NotNull;
+
+public class GetInventoryQuery {
+    
+    @NotNull(message = "SKU ID is required")
+    private final String skuId;
+    
+    public GetInventoryQuery(String skuId) {
+        this.skuId = skuId;
+    }
+    
+    public String getSkuId() {
+        return skuId;
+    }
+}

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/GetInventoryUseCase.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/GetInventoryUseCase.java
@@ -1,0 +1,6 @@
+package com.commerce.inventory.application.port.in;
+
+import com.commerce.common.application.usecase.UseCase;
+
+public interface GetInventoryUseCase extends UseCase<GetInventoryQuery, InventoryResponse> {
+}

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/InventoryResponse.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/InventoryResponse.java
@@ -1,0 +1,32 @@
+package com.commerce.inventory.application.port.in;
+
+public class InventoryResponse {
+    
+    private final String skuId;
+    private final int totalQuantity;
+    private final int reservedQuantity;
+    private final int availableQuantity;
+    
+    public InventoryResponse(String skuId, int totalQuantity, int reservedQuantity, int availableQuantity) {
+        this.skuId = skuId;
+        this.totalQuantity = totalQuantity;
+        this.reservedQuantity = reservedQuantity;
+        this.availableQuantity = availableQuantity;
+    }
+    
+    public String getSkuId() {
+        return skuId;
+    }
+    
+    public int getTotalQuantity() {
+        return totalQuantity;
+    }
+    
+    public int getReservedQuantity() {
+        return reservedQuantity;
+    }
+    
+    public int getAvailableQuantity() {
+        return availableQuantity;
+    }
+}

--- a/core/inventory-application/src/test/java/com/commerce/inventory/application/usecase/GetInventoryUseCaseTest.java
+++ b/core/inventory-application/src/test/java/com/commerce/inventory/application/usecase/GetInventoryUseCaseTest.java
@@ -1,0 +1,169 @@
+package com.commerce.inventory.application.usecase;
+
+import com.commerce.common.domain.model.Quantity;
+import com.commerce.inventory.application.port.in.GetInventoryQuery;
+import com.commerce.inventory.application.port.in.GetInventoryUseCase;
+import com.commerce.inventory.application.port.in.InventoryResponse;
+import com.commerce.inventory.application.port.out.LoadInventoryPort;
+import com.commerce.inventory.domain.exception.InvalidSkuIdException;
+import com.commerce.inventory.domain.model.Inventory;
+import com.commerce.inventory.domain.model.SkuId;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetInventoryUseCase 테스트")
+class GetInventoryUseCaseTest {
+    
+    @Mock
+    private LoadInventoryPort loadInventoryPort;
+    
+    @Mock
+    private Validator validator;
+    
+    private GetInventoryUseCase getInventoryUseCase;
+    
+    @BeforeEach
+    void setUp() {
+        getInventoryUseCase = new GetInventoryService(loadInventoryPort, validator);
+    }
+    
+    @Test
+    @DisplayName("정상적인 재고 조회 - 재고가 존재하는 경우")
+    void getInventory_WithExistingInventory_ReturnsInventoryResponse() {
+        // Given
+        String skuId = "SKU-001";
+        GetInventoryQuery query = new GetInventoryQuery(skuId);
+        
+        Inventory inventory = Inventory.create(
+            new SkuId(skuId),
+            Quantity.of(100),
+            Quantity.of(30)
+        );
+        
+        when(validator.validate(query)).thenReturn(Set.of());
+        when(loadInventoryPort.load(any(SkuId.class)))
+            .thenReturn(Optional.of(inventory));
+        
+        // When
+        InventoryResponse response = getInventoryUseCase.execute(query);
+        
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getSkuId()).isEqualTo(skuId);
+        assertThat(response.getTotalQuantity()).isEqualTo(100);
+        assertThat(response.getReservedQuantity()).isEqualTo(30);
+        assertThat(response.getAvailableQuantity()).isEqualTo(70);
+        
+        verify(loadInventoryPort).load(any(SkuId.class));
+        verify(validator).validate(query);
+    }
+    
+    @Test
+    @DisplayName("재고 조회 - 재고가 존재하지 않는 경우 0으로 반환")
+    void getInventory_WithNonExistingInventory_ReturnsZeroQuantities() {
+        // Given
+        String skuId = "SKU-999";
+        GetInventoryQuery query = new GetInventoryQuery(skuId);
+        
+        when(validator.validate(query)).thenReturn(Set.of());
+        when(loadInventoryPort.load(any(SkuId.class)))
+            .thenReturn(Optional.empty());
+        
+        // When
+        InventoryResponse response = getInventoryUseCase.execute(query);
+        
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getSkuId()).isEqualTo(skuId);
+        assertThat(response.getTotalQuantity()).isEqualTo(0);
+        assertThat(response.getReservedQuantity()).isEqualTo(0);
+        assertThat(response.getAvailableQuantity()).isEqualTo(0);
+        
+        verify(loadInventoryPort).load(any(SkuId.class));
+        verify(validator).validate(query);
+    }
+    
+    @Test
+    @DisplayName("재고 조회 - null SKU ID로 조회 시 예외 발생")
+    void getInventory_WithNullSkuId_ThrowsException() {
+        // Given
+        GetInventoryQuery query = new GetInventoryQuery(null);
+        
+        ConstraintViolation<GetInventoryQuery> violation = mock(ConstraintViolation.class);
+        when(violation.getMessage()).thenReturn("SKU ID is required");
+        when(validator.validate(query)).thenReturn(Set.of(violation));
+        
+        // When & Then
+        assertThatThrownBy(() -> getInventoryUseCase.execute(query))
+            .isInstanceOf(ConstraintViolationException.class);
+        
+        verify(validator).validate(query);
+        verify(loadInventoryPort, never()).load(any());
+    }
+    
+    @Test
+    @DisplayName("재고 조회 - 잘못된 형식의 SKU ID로 조회 시 예외 발생")
+    void getInventory_WithInvalidSkuIdFormat_ThrowsException() {
+        // Given
+        String invalidSkuId = "";
+        GetInventoryQuery query = new GetInventoryQuery(invalidSkuId);
+        
+        when(validator.validate(query)).thenReturn(Set.of());
+        
+        // When & Then
+        assertThatThrownBy(() -> getInventoryUseCase.execute(query))
+            .isInstanceOf(InvalidSkuIdException.class)
+            .hasMessageContaining("SKU ID는 필수입니다");
+        
+        verify(validator).validate(query);
+        verify(loadInventoryPort, never()).load(any());
+    }
+    
+    @Test
+    @DisplayName("재고 조회 - 모든 재고가 예약된 경우")
+    void getInventory_WithAllQuantityReserved_ReturnsZeroAvailable() {
+        // Given
+        String skuId = "SKU-001";
+        GetInventoryQuery query = new GetInventoryQuery(skuId);
+        
+        // 모든 재고가 예약된 상황
+        Inventory inventory = Inventory.create(
+            new SkuId(skuId),
+            Quantity.of(50),
+            Quantity.of(50)
+        );
+        
+        when(validator.validate(query)).thenReturn(Set.of());
+        when(loadInventoryPort.load(any(SkuId.class)))
+            .thenReturn(Optional.of(inventory));
+        
+        // When
+        InventoryResponse response = getInventoryUseCase.execute(query);
+        
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getSkuId()).isEqualTo(skuId);
+        assertThat(response.getTotalQuantity()).isEqualTo(50);
+        assertThat(response.getReservedQuantity()).isEqualTo(50);
+        assertThat(response.getAvailableQuantity()).isEqualTo(0);
+        
+        verify(loadInventoryPort).load(any(SkuId.class));
+        verify(validator).validate(query);
+    }
+}

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -88,7 +88,7 @@ PRD 문서와 설계 문서를 기반으로 수립한 구현 작업 계획입니
 - [x] ReserveStockUseCase
 - [ ] ReserveBundleStockUseCase (Saga 패턴 기반)
 - [ ] ReleaseReservationUseCase
-- [ ] GetInventoryUseCase
+- [x] GetInventoryUseCase
 
 #### 5.2 Product UseCase
 - [ ] CreateProductUseCase


### PR DESCRIPTION
## 요약
- GetInventoryUseCase를 TDD 방식으로 구현했습니다.
- 재고 조회 기능을 제공하며, 재고가 없는 경우 0으로 반환합니다.

## 구현 내용
- `GetInventoryQuery`: 재고 조회를 위한 쿼리 객체
- `GetInventoryUseCase`: 재고 조회 유스케이스 인터페이스
- `InventoryResponse`: 재고 정보 응답 DTO (SKU ID, 총 수량, 예약 수량, 가용 수량)
- `GetInventoryService`: 재고 조회 서비스 구현
- `GetInventoryUseCaseTest`: 단위 테스트 (5개 테스트 케이스)

## 테스트
- ✅ 정상적인 재고 조회 - 재고가 존재하는 경우
- ✅ 재고 조회 - 재고가 존재하지 않는 경우 0으로 반환
- ✅ 재고 조회 - null SKU ID로 조회 시 예외 발생
- ✅ 재고 조회 - 잘못된 형식의 SKU ID로 조회 시 예외 발생  
- ✅ 재고 조회 - 모든 재고가 예약된 경우

## 작업 완료
- [x] IMPLEMENTATION_PLAN.md의 GetInventoryUseCase 항목 완료 표시

Closes #31

🤖 Generated with [Claude Code](https://claude.ai/code)