### PR TITLE
feat(#30): 5.1 Inventory UseCase 의 ReleaseReservationUseCase 를 구현

### DIFF
--- a/core/inventory-application/build.gradle
+++ b/core/inventory-application/build.gradle
@@ -6,6 +6,7 @@ plugins {
 dependencies {
     api project(':inventory-domain')
     api project(':common')
+    implementation project(':product-domain')
     
     implementation 'org.springframework:spring-context'
     implementation 'org.springframework:spring-tx'

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/ReleaseReservationCommand.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/ReleaseReservationCommand.java
@@ -1,0 +1,18 @@
+package com.commerce.inventory.application.port.in;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import jakarta.validation.constraints.NotBlank;
+
+@Getter
+@Builder
+public class ReleaseReservationCommand {
+    
+    @NotBlank(message = "예약 ID는 필수입니다")
+    private final String reservationId;
+    
+    public ReleaseReservationCommand(String reservationId) {
+        this.reservationId = reservationId;
+    }
+}

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/ReleaseReservationUseCase.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/ReleaseReservationUseCase.java
@@ -1,0 +1,5 @@
+package com.commerce.inventory.application.port.in;
+
+public interface ReleaseReservationUseCase {
+    void release(ReleaseReservationCommand command);
+}

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReleaseReservationService.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReleaseReservationService.java
@@ -1,0 +1,47 @@
+package com.commerce.inventory.application.usecase;
+
+import com.commerce.inventory.application.port.in.ReleaseReservationCommand;
+import com.commerce.inventory.application.port.in.ReleaseReservationUseCase;
+import com.commerce.inventory.application.port.out.LoadInventoryPort;
+import com.commerce.inventory.application.port.out.SaveInventoryPort;
+import com.commerce.inventory.domain.exception.InvalidInventoryException;
+import com.commerce.inventory.domain.exception.InvalidReservationIdException;
+import com.commerce.inventory.domain.model.Inventory;
+import com.commerce.inventory.domain.model.Reservation;
+import com.commerce.inventory.domain.model.ReservationId;
+import com.commerce.inventory.domain.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReleaseReservationService implements ReleaseReservationUseCase {
+    
+    private final ReservationRepository reservationRepository;
+    private final LoadInventoryPort loadInventoryPort;
+    private final SaveInventoryPort saveInventoryPort;
+    
+    @Override
+    public void release(ReleaseReservationCommand command) {
+        ReservationId reservationId = new ReservationId(command.getReservationId());
+        
+        Reservation reservation = reservationRepository.findById(reservationId)
+            .orElseThrow(() -> new InvalidReservationIdException(
+                "예약을 찾을 수 없습니다: " + command.getReservationId()
+            ));
+        
+        reservation.release();
+        
+        Inventory inventory = loadInventoryPort.load(reservation.getSkuId())
+            .orElseThrow(() -> new InvalidInventoryException(
+                "재고를 찾을 수 없습니다: " + reservation.getSkuId().value()
+            ));
+        
+        inventory.releaseReservedQuantity(reservation.getQuantity());
+        
+        reservationRepository.save(reservation);
+        saveInventoryPort.save(inventory);
+    }
+}

--- a/core/inventory-application/src/test/java/com/commerce/inventory/application/usecase/ReleaseReservationUseCaseTest.java
+++ b/core/inventory-application/src/test/java/com/commerce/inventory/application/usecase/ReleaseReservationUseCaseTest.java
@@ -1,0 +1,268 @@
+package com.commerce.inventory.application.usecase;
+
+import com.commerce.common.domain.model.Quantity;
+import com.commerce.inventory.application.port.in.ReleaseReservationCommand;
+import com.commerce.inventory.application.port.in.ReleaseReservationUseCase;
+import com.commerce.inventory.application.port.out.LoadInventoryPort;
+import com.commerce.inventory.application.port.out.SaveInventoryPort;
+import com.commerce.inventory.domain.exception.InvalidReservationIdException;
+import com.commerce.inventory.domain.exception.InvalidReservationStateException;
+import com.commerce.inventory.domain.exception.InvalidInventoryException;
+import com.commerce.inventory.domain.model.*;
+import com.commerce.inventory.domain.repository.ReservationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReleaseReservationUseCase 테스트")
+class ReleaseReservationUseCaseTest {
+
+    private ReleaseReservationUseCase useCase;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+    
+    @Mock
+    private LoadInventoryPort loadInventoryPort;
+    
+    @Mock
+    private SaveInventoryPort saveInventoryPort;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new ReleaseReservationService(
+            reservationRepository,
+            loadInventoryPort,
+            saveInventoryPort
+        );
+    }
+
+    @Test
+    @DisplayName("정상적으로 예약을 해제할 수 있다")
+    void shouldReleaseReservationSuccessfully() {
+        // Given
+        String reservationIdValue = "RESV123";
+        ReservationId reservationId = new ReservationId(reservationIdValue);
+        SkuId skuId = new SkuId("SKU001");
+        Quantity reservedQuantity = Quantity.of(10);
+        
+        Reservation reservation = Reservation.create(
+            reservationId,
+            skuId,
+            reservedQuantity,
+            "ORDER001",
+            LocalDateTime.now().plusHours(1),
+            LocalDateTime.now()
+        );
+        
+        Inventory inventory = Inventory.create(
+            skuId,
+            Quantity.of(100),
+            Quantity.of(50)
+        );
+        
+        given(reservationRepository.findById(reservationId))
+            .willReturn(Optional.of(reservation));
+        given(loadInventoryPort.load(skuId))
+            .willReturn(Optional.of(inventory));
+        
+        ReleaseReservationCommand command = ReleaseReservationCommand.builder()
+            .reservationId(reservationIdValue)
+            .build();
+        
+        // When
+        useCase.release(command);
+        
+        // Then
+        then(reservationRepository).should().save(reservation);
+        then(saveInventoryPort).should().save(inventory);
+        
+        assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.RELEASED);
+        assertThat(inventory.getReservedQuantity()).isEqualTo(Quantity.of(40));
+    }
+    
+    @Test
+    @DisplayName("존재하지 않는 예약 ID로 해제 시도시 예외가 발생한다")
+    void shouldThrowExceptionWhenReservationNotFound() {
+        // Given
+        String reservationIdValue = "NOT_EXISTS";
+        ReservationId reservationId = new ReservationId(reservationIdValue);
+        
+        given(reservationRepository.findById(reservationId))
+            .willReturn(Optional.empty());
+        
+        ReleaseReservationCommand command = ReleaseReservationCommand.builder()
+            .reservationId(reservationIdValue)
+            .build();
+        
+        // When & Then
+        assertThatThrownBy(() -> useCase.release(command))
+            .isInstanceOf(InvalidReservationIdException.class)
+            .hasMessage("예약을 찾을 수 없습니다: " + reservationIdValue);
+        
+        then(saveInventoryPort).should(never()).save(any());
+        then(reservationRepository).should(never()).save(any());
+    }
+    
+    @Test
+    @DisplayName("이미 해제된 예약을 다시 해제 시도시 예외가 발생한다")
+    void shouldThrowExceptionWhenReservationAlreadyReleased() {
+        // Given
+        String reservationIdValue = "RESV123";
+        ReservationId reservationId = new ReservationId(reservationIdValue);
+        SkuId skuId = new SkuId("SKU001");
+        
+        Reservation reservation = Reservation.create(
+            reservationId,
+            skuId,
+            Quantity.of(10),
+            "ORDER001",
+            LocalDateTime.now().plusHours(1),
+            LocalDateTime.now()
+        );
+        reservation.release(); // 이미 해제된 상태
+        
+        given(reservationRepository.findById(reservationId))
+            .willReturn(Optional.of(reservation));
+        
+        ReleaseReservationCommand command = ReleaseReservationCommand.builder()
+            .reservationId(reservationIdValue)
+            .build();
+        
+        // When & Then
+        assertThatThrownBy(() -> useCase.release(command))
+            .isInstanceOf(InvalidReservationStateException.class)
+            .hasMessage("이미 해제된 예약입니다");
+        
+        then(loadInventoryPort).should(never()).load(any());
+        then(saveInventoryPort).should(never()).save(any());
+    }
+    
+    @Test
+    @DisplayName("만료된 예약도 해제할 수 있다")
+    void shouldReleaseExpiredReservation() {
+        // Given
+        String reservationIdValue = "RESV123";
+        ReservationId reservationId = new ReservationId(reservationIdValue);
+        SkuId skuId = new SkuId("SKU001");
+        Quantity reservedQuantity = Quantity.of(10);
+        
+        Reservation reservation = Reservation.create(
+            reservationId,
+            skuId,
+            reservedQuantity,
+            "ORDER001",
+            LocalDateTime.now().minusHours(1), // 만료된 예약
+            LocalDateTime.now().minusHours(2)
+        );
+        
+        Inventory inventory = Inventory.create(
+            skuId,
+            Quantity.of(100),
+            Quantity.of(50)
+        );
+        
+        given(reservationRepository.findById(reservationId))
+            .willReturn(Optional.of(reservation));
+        given(loadInventoryPort.load(skuId))
+            .willReturn(Optional.of(inventory));
+        
+        ReleaseReservationCommand command = ReleaseReservationCommand.builder()
+            .reservationId(reservationIdValue)
+            .build();
+        
+        // When
+        useCase.release(command);
+        
+        // Then
+        then(reservationRepository).should().save(reservation);
+        then(saveInventoryPort).should().save(inventory);
+        
+        assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.RELEASED);
+        assertThat(inventory.getReservedQuantity()).isEqualTo(Quantity.of(40));
+    }
+    
+    @Test
+    @DisplayName("재고가 없는 경우 예외가 발생한다")
+    void shouldThrowExceptionWhenInventoryNotFound() {
+        // Given
+        String reservationIdValue = "RESV123";
+        ReservationId reservationId = new ReservationId(reservationIdValue);
+        SkuId skuId = new SkuId("SKU001");
+        
+        Reservation reservation = Reservation.create(
+            reservationId,
+            skuId,
+            Quantity.of(10),
+            "ORDER001",
+            LocalDateTime.now().plusHours(1),
+            LocalDateTime.now()
+        );
+        
+        given(reservationRepository.findById(reservationId))
+            .willReturn(Optional.of(reservation));
+        given(loadInventoryPort.load(skuId))
+            .willReturn(Optional.empty());
+        
+        ReleaseReservationCommand command = ReleaseReservationCommand.builder()
+            .reservationId(reservationIdValue)
+            .build();
+        
+        // When & Then
+        assertThatThrownBy(() -> useCase.release(command))
+            .isInstanceOf(InvalidInventoryException.class)
+            .hasMessage("재고를 찾을 수 없습니다: " + skuId.value());
+        
+        then(saveInventoryPort).should(never()).save(any());
+    }
+    
+    @Test
+    @DisplayName("확정된 예약은 해제할 수 없다")
+    void shouldNotReleaseConfirmedReservation() {
+        // Given
+        String reservationIdValue = "RESV123";
+        ReservationId reservationId = new ReservationId(reservationIdValue);
+        SkuId skuId = new SkuId("SKU001");
+        
+        Reservation reservation = Reservation.create(
+            reservationId,
+            skuId,
+            Quantity.of(10),
+            "ORDER001",
+            LocalDateTime.now().plusHours(1),
+            LocalDateTime.now()
+        );
+        reservation.confirm(LocalDateTime.now()); // 확정된 상태
+        
+        given(reservationRepository.findById(reservationId))
+            .willReturn(Optional.of(reservation));
+        
+        ReleaseReservationCommand command = ReleaseReservationCommand.builder()
+            .reservationId(reservationIdValue)
+            .build();
+        
+        // When & Then
+        assertThatThrownBy(() -> useCase.release(command))
+            .isInstanceOf(InvalidReservationStateException.class)
+            .hasMessage("확정된 예약은 해제할 수 없습니다");
+        
+        then(loadInventoryPort).should(never()).load(any());
+        then(saveInventoryPort).should(never()).save(any());
+    }
+}

--- a/core/inventory-domain/src/main/java/com/commerce/inventory/domain/model/Reservation.java
+++ b/core/inventory-domain/src/main/java/com/commerce/inventory/domain/model/Reservation.java
@@ -79,6 +79,10 @@ public class Reservation extends BaseEntity<ReservationId> {
             throw new InvalidReservationStateException("이미 해제된 예약입니다");
         }
         
+        if (status == ReservationStatus.CONFIRMED) {
+            throw new InvalidReservationStateException("확정된 예약은 해제할 수 없습니다");
+        }
+        
         this.status = ReservationStatus.RELEASED;
     }
     

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -87,7 +87,7 @@ PRD 문서와 설계 문서를 기반으로 수립한 구현 작업 계획입니
 - [x] ReceiveStockUseCase
 - [x] ReserveStockUseCase
 - [ ] ReserveBundleStockUseCase (Saga 패턴 기반)
-- [ ] ReleaseReservationUseCase
+- [x] ReleaseReservationUseCase
 - [x] GetInventoryUseCase
 
 #### 5.2 Product UseCase


### PR DESCRIPTION
## 작업 내용

5.1 Inventory UseCase 의 ReleaseReservationUseCase를 TDD 방식으로 구현했습니다.

## 주요 변경 사항

### 1. ReleaseReservationUseCase 구현
- **ReleaseReservationCommand**: 예약 해제를 위한 Command 객체
- **ReleaseReservationUseCase**: 예약 해제 UseCase 인터페이스
- **ReleaseReservationService**: UseCase 구현체
  - 예약 ID로 예약 조회 및 검증
  - 예약 해제 시 재고의 예약 수량 복원
  - 트랜잭션 처리

### 2. 비즈니스 규칙
- 존재하지 않는 예약은 해제 불가
- 이미 해제된 예약은 재해제 불가
- 확정된 예약은 해제 불가
- 만료된 예약도 해제 가능 (재고 복원)

### 3. 도메인 모델 개선
- Reservation 모델에 확정된 예약 해제 방지 로직 추가

### 4. 테스트
- 정상 해제 케이스
- 만료된 예약 해제 케이스
- 예외 케이스들 (존재하지 않는 예약, 이미 해제된 예약, 확정된 예약, 재고 없음)

## 테스트 결과
모든 테스트가 성공적으로 통과했습니다.

```
BUILD SUCCESSFUL in 5s
10 actionable tasks: 2 executed, 8 up-to-date
```

Closes #30