### PR TITLE
5.1 Inventory UseCase 의 ReserveBundleStockUseCase 를 구현

### DIFF
--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/config/ClockConfig.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/config/ClockConfig.java
@@ -1,0 +1,15 @@
+package com.commerce.inventory.application.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class ClockConfig {
+    
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/config/ClockConfig.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/config/ClockConfig.java
@@ -10,6 +10,6 @@ public class ClockConfig {
     
     @Bean
     public Clock clock() {
-        return Clock.systemDefaultZone();
+        return Clock.systemUTC();
     }
 }

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/BundleReservationResponse.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/BundleReservationResponse.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class BundleReservationResponse {
     private String sagaId;
     private String orderId;
-    private String status;
+    private BundleReservationStatus status;
     private List<SkuReservation> skuReservations;
     private String failureReason;
     
@@ -28,6 +28,6 @@ public class BundleReservationResponse {
         private String reservationId;
         private Integer quantity;
         private LocalDateTime expiresAt;
-        private String status;
+        private SkuReservationStatus status;
     }
 }

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/BundleReservationResponse.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/BundleReservationResponse.java
@@ -1,0 +1,33 @@
+package com.commerce.inventory.application.port.in;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BundleReservationResponse {
+    private String sagaId;
+    private String orderId;
+    private String status;
+    private List<SkuReservation> skuReservations;
+    private String failureReason;
+    
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SkuReservation {
+        private String skuId;
+        private String reservationId;
+        private Integer quantity;
+        private LocalDateTime expiresAt;
+        private String status;
+    }
+}

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/BundleReservationStatus.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/BundleReservationStatus.java
@@ -1,0 +1,6 @@
+package com.commerce.inventory.application.port.in;
+
+public enum BundleReservationStatus {
+    COMPLETED,
+    FAILED
+}

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/ReserveBundleStockCommand.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/ReserveBundleStockCommand.java
@@ -27,6 +27,7 @@ public class ReserveBundleStockCommand {
     @Valid
     private List<BundleItem> bundleItems;
     
+    @Positive(message = "TTL은 0보다 커야 합니다")
     private Integer ttlSeconds;
     
     @Getter

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/ReserveBundleStockCommand.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/ReserveBundleStockCommand.java
@@ -20,8 +20,8 @@ public class ReserveBundleStockCommand {
     @NotBlank(message = "주문 ID는 필수입니다")
     private String orderId;
     
-    @NotBlank(message = "예약 ID는 필수입니다")
-    private String reservationId;
+    @NotBlank(message = "Saga ID는 필수입니다")
+    private String sagaId;
     
     @NotEmpty(message = "번들 항목은 최소 1개 이상이어야 합니다")
     @Valid

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/ReserveBundleStockCommand.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/ReserveBundleStockCommand.java
@@ -1,0 +1,38 @@
+package com.commerce.inventory.application.port.in;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReserveBundleStockCommand {
+    private String orderId;
+    private String reservationId;
+    private List<BundleItem> bundleItems;
+    private Integer ttlSeconds;
+    
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BundleItem {
+        private String productOptionId;
+        private List<SkuMapping> skuMappings;
+        private Integer quantity;
+    }
+    
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SkuMapping {
+        private String skuId;
+        private Integer quantity;
+    }
+}

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/ReserveBundleStockCommand.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/ReserveBundleStockCommand.java
@@ -1,5 +1,10 @@
 package com.commerce.inventory.application.port.in;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,9 +17,16 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ReserveBundleStockCommand {
+    @NotBlank(message = "주문 ID는 필수입니다")
     private String orderId;
+    
+    @NotBlank(message = "예약 ID는 필수입니다")
     private String reservationId;
+    
+    @NotEmpty(message = "번들 항목은 최소 1개 이상이어야 합니다")
+    @Valid
     private List<BundleItem> bundleItems;
+    
     private Integer ttlSeconds;
     
     @Getter
@@ -22,8 +34,15 @@ public class ReserveBundleStockCommand {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class BundleItem {
+        @NotBlank(message = "상품 옵션 ID는 필수입니다")
         private String productOptionId;
+        
+        @NotEmpty(message = "SKU 매핑은 최소 1개 이상이어야 합니다")
+        @Valid
         private List<SkuMapping> skuMappings;
+        
+        @NotNull(message = "번들 수량은 필수입니다")
+        @Positive(message = "번들 수량은 0보다 커야 합니다")
         private Integer quantity;
     }
     
@@ -32,7 +51,11 @@ public class ReserveBundleStockCommand {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class SkuMapping {
+        @NotBlank(message = "SKU ID는 필수입니다")
         private String skuId;
+        
+        @NotNull(message = "SKU 수량은 필수입니다")
+        @Positive(message = "SKU 수량은 0보다 커야 합니다")
         private Integer quantity;
     }
 }

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/ReserveBundleStockUseCase.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/ReserveBundleStockUseCase.java
@@ -1,0 +1,6 @@
+package com.commerce.inventory.application.port.in;
+
+import com.commerce.common.application.usecase.UseCase;
+
+public interface ReserveBundleStockUseCase extends UseCase<ReserveBundleStockCommand, BundleReservationResponse> {
+}

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/SkuReservationStatus.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/port/in/SkuReservationStatus.java
@@ -1,0 +1,7 @@
+package com.commerce.inventory.application.port.in;
+
+public enum SkuReservationStatus {
+    ACTIVE,
+    EXPIRED,
+    CANCELLED
+}

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/port/out/LoadInventoryPort.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/port/out/LoadInventoryPort.java
@@ -3,8 +3,12 @@ package com.commerce.inventory.application.port.out;
 import com.commerce.inventory.domain.model.Inventory;
 import com.commerce.inventory.domain.model.SkuId;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface LoadInventoryPort {
     Optional<Inventory> load(SkuId skuId);
+    
+    Map<SkuId, Inventory> loadAllByIds(List<SkuId> skuIds);
 }

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/port/out/SaveInventoryPort.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/port/out/SaveInventoryPort.java
@@ -2,6 +2,9 @@ package com.commerce.inventory.application.port.out;
 
 import com.commerce.inventory.domain.model.Inventory;
 
+import java.util.Collection;
+
 public interface SaveInventoryPort {
     void save(Inventory inventory);
+    void saveAll(Collection<Inventory> inventories);
 }

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
@@ -73,6 +73,9 @@ public class ReserveBundleStockService implements ReserveBundleStockUseCase {
             
             // 실패 응답 생성 (트랜잭션이 자동으로 롤백됨)
             return createFailureResponse(sagaId, command.getOrderId(), e.getMessage());
+        } catch (org.springframework.dao.OptimisticLockingFailureException e) {
+            log.warn("번들 재고 예약 중 동시성 충돌 발생: sagaId={}, error={}", sagaId, e.getMessage());
+            return createFailureResponse(sagaId, command.getOrderId(), "일시적인 오류가 발생했습니다. 다시 시도해주세요.");
         }
     }
 

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
@@ -139,17 +139,7 @@ public class ReserveBundleStockService implements ReserveBundleStockUseCase {
     ) {
         Quantity requestedQuantity = Quantity.of(quantity);
         
-        // 재고 가용성 확인
-        if (!inventory.canReserve(requestedQuantity)) {
-            throw new InsufficientStockException(
-                String.format("재고가 부족합니다. SKU: %s, 가용 재고: %d, 요청 수량: %d",
-                    inventory.getSkuId().value(), 
-                    inventory.getAvailableQuantity().value(), 
-                    quantity)
-            );
-        }
-        
-        // 재고 예약
+        // 재고 예약 (도메인 객체가 재고 확인 및 예외 처리 담당)
         ReservationId reservationId = inventory.reserve(requestedQuantity);
         
         // 예약 엔티티 생성

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
@@ -45,10 +45,13 @@ public class ReserveBundleStockService implements ReserveBundleStockUseCase {
     @Override
     @Transactional
     public BundleReservationResponse execute(ReserveBundleStockCommand command) {
+        String sagaId = null;
+        String orderId = null;
+        
         try {
             validateCommand(command);
-            String sagaId = command.getSagaId();
-            String orderId = command.getOrderId();
+            sagaId = command.getSagaId();
+            orderId = command.getOrderId();
 
             // 1. 모든 개별 예약 요청 계산
             List<SkuReservationRequest> skuRequests = parseSkuRequests(command);
@@ -70,18 +73,22 @@ public class ReserveBundleStockService implements ReserveBundleStockUseCase {
 
         } catch (IllegalArgumentException e) {
             log.error("번들 재고 예약 실패 (잘못된 요청): {}", e.getMessage(), e);
-            String sagaId = (command != null) ? command.getSagaId() : null;
-            String orderId = (command != null) ? command.getOrderId() : null;
+            if (sagaId == null && command != null) {
+                sagaId = command.getSagaId();
+            }
+            if (orderId == null && command != null) {
+                orderId = command.getOrderId();
+            }
             return createFailureResponse(sagaId, orderId, e.getMessage());
         } catch (InsufficientStockException | InvalidInventoryException e) {
-            log.error("번들 재고 예약 실패: sagaId={}, error={}", command.getSagaId(), e.getMessage(), e);
-            return createFailureResponse(command.getSagaId(), command.getOrderId(), e.getMessage());
+            log.error("번들 재고 예약 실패: sagaId={}, error={}", sagaId, e.getMessage(), e);
+            return createFailureResponse(sagaId, orderId, e.getMessage());
         } catch (ArithmeticException e) {
-            log.error("번들 재고 예약 실패 (수량 계산 오버플로우): sagaId={}, error={}", command.getSagaId(), e.getMessage(), e);
-            return createFailureResponse(command.getSagaId(), command.getOrderId(), "요청 수량이 너무 많아 처리할 수 없습니다.");
+            log.error("번들 재고 예약 실패 (수량 계산 오버플로우): sagaId={}, error={}", sagaId, e.getMessage(), e);
+            return createFailureResponse(sagaId, orderId, "요청 수량이 너무 많아 처리할 수 없습니다.");
         } catch (org.springframework.dao.OptimisticLockingFailureException e) {
-            log.warn("번들 재고 예약 중 동시성 충돌 발생: sagaId={}, error={}", command.getSagaId(), e.getMessage());
-            return createFailureResponse(command.getSagaId(), command.getOrderId(), "일시적인 오류가 발생했습니다. 다시 시도해주세요.");
+            log.warn("번들 재고 예약 중 동시성 충돌 발생: sagaId={}, error={}", sagaId, e.getMessage());
+            return createFailureResponse(sagaId, orderId, "일시적인 오류가 발생했습니다. 다시 시도해주세요.");
         }
     }
 

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
@@ -82,7 +82,7 @@ public class ReserveBundleStockService implements ReserveBundleStockUseCase {
         return command.getBundleItems().stream()
             .flatMap(bundleItem -> bundleItem.getSkuMappings().stream()
                 .map(skuMapping -> new SkuReservationRequest(
-                    new SkuId(skuMapping.getSkuId()),
+                    SkuId.of(skuMapping.getSkuId()),
                     Quantity.of(skuMapping.getQuantity() * bundleItem.getQuantity())
                 ))
             )

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
@@ -92,10 +92,12 @@ public class ReserveBundleStockService implements ReserveBundleStockUseCase {
 
     private Map<SkuId, Quantity> calculateTotalRequiredQuantities(List<SkuReservationRequest> skuRequests) {
         return skuRequests.stream()
-            .collect(Collectors.toMap(
+            .collect(Collectors.groupingBy(
                 SkuReservationRequest::skuId,
-                SkuReservationRequest::quantity,
-                Quantity::add
+                Collectors.mapping(
+                    SkuReservationRequest::quantity,
+                    Collectors.reducing(Quantity.zero(), Quantity::add)
+                )
             ));
     }
 

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
@@ -1,0 +1,291 @@
+package com.commerce.inventory.application.usecase;
+
+import com.commerce.common.domain.model.Quantity;
+import com.commerce.inventory.application.port.in.BundleReservationResponse;
+import com.commerce.inventory.application.port.in.ReserveBundleStockCommand;
+import com.commerce.inventory.application.port.in.ReserveBundleStockUseCase;
+import com.commerce.inventory.application.port.out.LoadInventoryPort;
+import com.commerce.inventory.application.port.out.SaveInventoryPort;
+import com.commerce.inventory.domain.exception.InsufficientStockException;
+import com.commerce.inventory.domain.exception.InvalidInventoryException;
+import com.commerce.inventory.domain.model.Inventory;
+import com.commerce.inventory.domain.model.Reservation;
+import com.commerce.inventory.domain.model.ReservationId;
+import com.commerce.inventory.domain.model.SkuId;
+import com.commerce.inventory.domain.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReserveBundleStockService implements ReserveBundleStockUseCase {
+    
+    private static final int DEFAULT_TTL_SECONDS = 900; // 15분
+    
+    private final LoadInventoryPort loadInventoryPort;
+    private final SaveInventoryPort saveInventoryPort;
+    private final ReservationRepository reservationRepository;
+    
+    @Override
+    @Transactional
+    public BundleReservationResponse execute(ReserveBundleStockCommand command) {
+        validateCommand(command);
+        
+        String sagaId = command.getReservationId();
+        List<ReservedItem> reservedItems = new ArrayList<>();
+        
+        try {
+            // 모든 번들 항목을 순차적으로 처리
+            for (ReserveBundleStockCommand.BundleItem bundleItem : command.getBundleItems()) {
+                List<ReservedItem> bundleReservedItems = reserveBundleItem(
+                    bundleItem, 
+                    command.getOrderId(), 
+                    command.getTtlSeconds()
+                );
+                reservedItems.addAll(bundleReservedItems);
+            }
+            
+            // 성공 응답 생성
+            return createSuccessResponse(sagaId, command.getOrderId(), reservedItems);
+            
+        } catch (Exception e) {
+            log.error("번들 재고 예약 실패: sagaId={}, error={}", sagaId, e.getMessage(), e);
+            
+            // 실패 시 이미 예약된 항목들을 롤백
+            rollbackReservations(reservedItems);
+            
+            // 실패 응답 생성
+            return createFailureResponse(sagaId, command.getOrderId(), e.getMessage());
+        }
+    }
+    
+    private List<ReservedItem> reserveBundleItem(
+        ReserveBundleStockCommand.BundleItem bundleItem,
+        String orderId,
+        Integer ttlSeconds
+    ) {
+        List<ReservedItem> reservedItems = new ArrayList<>();
+        
+        // 번들의 각 SKU에 대해 필요한 수량 계산
+        for (ReserveBundleStockCommand.SkuMapping skuMapping : bundleItem.getSkuMappings()) {
+            int requiredQuantity = skuMapping.getQuantity() * bundleItem.getQuantity();
+            
+            // 재고 조회
+            SkuId skuId = new SkuId(skuMapping.getSkuId());
+            Inventory inventory = loadInventoryPort.load(skuId)
+                .orElseThrow(() -> new InvalidInventoryException(
+                    "재고를 찾을 수 없습니다: " + skuMapping.getSkuId()
+                ));
+            
+            // 재고 예약
+            ReservedItem reservedItem = reserveInventory(
+                inventory,
+                requiredQuantity,
+                orderId,
+                ttlSeconds != null ? ttlSeconds : DEFAULT_TTL_SECONDS
+            );
+            
+            reservedItems.add(reservedItem);
+        }
+        
+        return reservedItems;
+    }
+    
+    private ReservedItem reserveInventory(
+        Inventory inventory,
+        int quantity,
+        String orderId,
+        int ttlSeconds
+    ) {
+        Quantity requestedQuantity = Quantity.of(quantity);
+        
+        // 재고 가용성 확인
+        if (!inventory.canReserve(requestedQuantity)) {
+            throw new InsufficientStockException(
+                String.format("재고가 부족합니다. SKU: %s, 가용 재고: %d, 요청 수량: %d",
+                    inventory.getSkuId().value(), 
+                    inventory.getAvailableQuantity().value(), 
+                    quantity)
+            );
+        }
+        
+        // 재고 예약
+        ReservationId reservationId = inventory.reserve(requestedQuantity);
+        
+        // 예약 엔티티 생성
+        LocalDateTime now = LocalDateTime.now();
+        Reservation reservation = Reservation.create(
+            reservationId,
+            inventory.getSkuId(),
+            requestedQuantity,
+            orderId,
+            now.plusSeconds(ttlSeconds),
+            now
+        );
+        
+        // 예약 저장
+        Reservation savedReservation = reservationRepository.save(reservation);
+        
+        // 재고 저장
+        saveInventoryPort.save(inventory);
+        
+        return new ReservedItem(
+            inventory.getSkuId(),
+            reservation.getId(),
+            reservation.getQuantity(),
+            reservation.getExpiresAt(),
+            inventory
+        );
+    }
+    
+    private void rollbackReservations(List<ReservedItem> reservedItems) {
+        for (ReservedItem item : reservedItems) {
+            try {
+                // 예약 조회
+                Reservation reservation = reservationRepository.findById(item.reservationId)
+                    .orElse(null);
+                
+                if (reservation != null && reservation.isActive(LocalDateTime.now())) {
+                    // 예약 해제
+                    reservation.release();
+                    reservationRepository.save(reservation);
+                    
+                    // 재고의 예약 수량 복원
+                    item.inventory.releaseReservedQuantity(item.quantity);
+                    saveInventoryPort.save(item.inventory);
+                }
+            } catch (Exception e) {
+                log.error("예약 롤백 실패: reservationId={}, error={}", 
+                    item.reservationId.value(), e.getMessage(), e);
+            }
+        }
+    }
+    
+    private BundleReservationResponse createSuccessResponse(
+        String sagaId,
+        String orderId,
+        List<ReservedItem> reservedItems
+    ) {
+        List<BundleReservationResponse.SkuReservation> skuReservations = reservedItems.stream()
+            .map(item -> BundleReservationResponse.SkuReservation.builder()
+                .skuId(item.skuId.value())
+                .reservationId(item.reservationId.value())
+                .quantity(item.quantity.value())
+                .expiresAt(item.expiresAt)
+                .status("ACTIVE")
+                .build())
+            .collect(Collectors.toList());
+        
+        return BundleReservationResponse.builder()
+            .sagaId(sagaId)
+            .orderId(orderId)
+            .status("COMPLETED")
+            .skuReservations(skuReservations)
+            .failureReason(null)
+            .build();
+    }
+    
+    private BundleReservationResponse createFailureResponse(
+        String sagaId,
+        String orderId,
+        String failureReason
+    ) {
+        return BundleReservationResponse.builder()
+            .sagaId(sagaId)
+            .orderId(orderId)
+            .status("FAILED")
+            .skuReservations(Collections.emptyList())
+            .failureReason(failureReason)
+            .build();
+    }
+    
+    private void validateCommand(ReserveBundleStockCommand command) {
+        if (command == null) {
+            throw new IllegalArgumentException("예약 요청이 null일 수 없습니다");
+        }
+        
+        if (command.getOrderId() == null || command.getOrderId().trim().isEmpty()) {
+            throw new IllegalArgumentException("주문 ID는 필수입니다");
+        }
+        
+        if (command.getReservationId() == null || command.getReservationId().trim().isEmpty()) {
+            throw new IllegalArgumentException("예약 ID는 필수입니다");
+        }
+        
+        if (command.getBundleItems() == null || command.getBundleItems().isEmpty()) {
+            throw new IllegalArgumentException("번들 항목은 최소 1개 이상이어야 합니다");
+        }
+        
+        // 각 번들 항목 검증
+        for (ReserveBundleStockCommand.BundleItem item : command.getBundleItems()) {
+            validateBundleItem(item);
+        }
+    }
+    
+    private void validateBundleItem(ReserveBundleStockCommand.BundleItem item) {
+        if (item == null) {
+            throw new IllegalArgumentException("번들 항목이 null일 수 없습니다");
+        }
+        
+        if (item.getProductOptionId() == null || item.getProductOptionId().trim().isEmpty()) {
+            throw new IllegalArgumentException("상품 옵션 ID는 필수입니다");
+        }
+        
+        if (item.getQuantity() == null || item.getQuantity() <= 0) {
+            throw new IllegalArgumentException("번들 수량은 0보다 커야 합니다");
+        }
+        
+        if (item.getSkuMappings() == null || item.getSkuMappings().isEmpty()) {
+            throw new IllegalArgumentException("SKU 매핑은 최소 1개 이상이어야 합니다");
+        }
+        
+        // 각 SKU 매핑 검증
+        for (ReserveBundleStockCommand.SkuMapping mapping : item.getSkuMappings()) {
+            validateSkuMapping(mapping);
+        }
+    }
+    
+    private void validateSkuMapping(ReserveBundleStockCommand.SkuMapping mapping) {
+        if (mapping == null) {
+            throw new IllegalArgumentException("SKU 매핑이 null일 수 없습니다");
+        }
+        
+        if (mapping.getSkuId() == null || mapping.getSkuId().trim().isEmpty()) {
+            throw new IllegalArgumentException("SKU ID는 필수입니다");
+        }
+        
+        if (mapping.getQuantity() == null || mapping.getQuantity() <= 0) {
+            throw new IllegalArgumentException("SKU 수량은 0보다 커야 합니다");
+        }
+    }
+    
+    // 내부 클래스: 예약된 항목 정보
+    private static class ReservedItem {
+        final SkuId skuId;
+        final ReservationId reservationId;
+        final Quantity quantity;
+        final LocalDateTime expiresAt;
+        final Inventory inventory;
+        
+        ReservedItem(
+            SkuId skuId,
+            ReservationId reservationId,
+            Quantity quantity,
+            LocalDateTime expiresAt,
+            Inventory inventory
+        ) {
+            this.skuId = skuId;
+            this.reservationId = reservationId;
+            this.quantity = quantity;
+            this.expiresAt = expiresAt;
+            this.inventory = inventory;
+        }
+    }
+}

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
@@ -113,9 +113,8 @@ public class ReserveBundleStockService implements ReserveBundleStockUseCase {
 
     private void validateInventoryExists(List<SkuId> requiredSkuIds, Map<SkuId, Inventory> inventoryMap) {
         if (inventoryMap.size() != requiredSkuIds.size()) {
-            Set<SkuId> missingSkuIdSet = new HashSet<>(requiredSkuIds);
-            missingSkuIdSet.removeAll(inventoryMap.keySet());
-            String missingSkuIds = missingSkuIdSet.stream()
+            String missingSkuIds = requiredSkuIds.stream()
+                    .filter(id -> !inventoryMap.containsKey(id))
                     .map(SkuId::value)
                     .collect(Collectors.joining(", "));
             throw new InvalidInventoryException("다음 SKU에 대한 재고 정보를 찾을 수 없습니다: " + missingSkuIds);

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
@@ -18,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -32,6 +33,7 @@ public class ReserveBundleStockService implements ReserveBundleStockUseCase {
     private final LoadInventoryPort loadInventoryPort;
     private final SaveInventoryPort saveInventoryPort;
     private final ReservationRepository reservationRepository;
+    private final Clock clock;
     
     @Override
     @Transactional
@@ -139,7 +141,7 @@ public class ReserveBundleStockService implements ReserveBundleStockUseCase {
         ReservationId reservationId = inventory.reserve(requestedQuantity);
         
         // 예약 엔티티 생성
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now(clock);
         Reservation reservation = Reservation.create(
             reservationId,
             inventory.getSkuId(),

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
@@ -113,9 +113,9 @@ public class ReserveBundleStockService implements ReserveBundleStockUseCase {
 
     private void validateInventoryExists(List<SkuId> requiredSkuIds, Map<SkuId, Inventory> inventoryMap) {
         if (inventoryMap.size() != requiredSkuIds.size()) {
-            Set<SkuId> foundSkuIds = inventoryMap.keySet();
-            String missingSkuIds = requiredSkuIds.stream()
-                    .filter(id -> !foundSkuIds.contains(id))
+            Set<SkuId> missingSkuIdSet = new HashSet<>(requiredSkuIds);
+            missingSkuIdSet.removeAll(inventoryMap.keySet());
+            String missingSkuIds = missingSkuIdSet.stream()
                     .map(SkuId::value)
                     .collect(Collectors.joining(", "));
             throw new InvalidInventoryException("다음 SKU에 대한 재고 정보를 찾을 수 없습니다: " + missingSkuIds);

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
@@ -153,7 +153,7 @@ public class ReserveBundleStockService implements ReserveBundleStockUseCase {
         Map<SkuId, Inventory> inventoryMap
     ) {
         Set<Inventory> modifiedInventories = new HashSet<>();
-        List<Reservation> reservationsToSave = new ArrayList<>();
+        List<Reservation> reservationsToSave = new ArrayList<>(skuRequests.size());
         
         int ttlSeconds = Optional.ofNullable(command.getTtlSeconds()).orElse(defaultTtlSeconds);
         LocalDateTime now = LocalDateTime.now(clock);

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
@@ -149,7 +149,7 @@ public class ReserveBundleStockService implements ReserveBundleStockUseCase {
         Set<Inventory> modifiedInventories = new HashSet<>();
         List<Reservation> reservationsToSave = new ArrayList<>();
         
-        int ttlSeconds = command.getTtlSeconds() != null ? command.getTtlSeconds() : defaultTtlSeconds;
+        int ttlSeconds = Optional.ofNullable(command.getTtlSeconds()).orElse(defaultTtlSeconds);
         LocalDateTime now = LocalDateTime.now(clock);
         LocalDateTime expiresAt = now.plusSeconds(ttlSeconds);
         

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
@@ -90,12 +90,10 @@ public class ReserveBundleStockService implements ReserveBundleStockUseCase {
 
     private Map<SkuId, Quantity> calculateTotalRequiredQuantities(List<SkuReservationRequest> skuRequests) {
         return skuRequests.stream()
-            .collect(Collectors.groupingBy(
+            .collect(Collectors.toMap(
                 SkuReservationRequest::skuId,
-                Collectors.mapping(
-                    SkuReservationRequest::quantity,
-                    Collectors.reducing(Quantity.zero(), (q1, q2) -> Quantity.of(Math.addExact(q1.value(), q2.value())))
-                )
+                SkuReservationRequest::quantity,
+                (q1, q2) -> Quantity.of(Math.addExact(q1.value(), q2.value()))
             ));
     }
 

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
@@ -68,11 +68,12 @@ public class ReserveBundleStockService implements ReserveBundleStockUseCase {
             // 5. 성공 응답 생성
             return createSuccessResponse(sagaId, command.getOrderId(), savedReservations);
             
-        } catch (InsufficientStockException | InvalidInventoryException | ArithmeticException e) {
+        } catch (InsufficientStockException | InvalidInventoryException e) {
             log.error("번들 재고 예약 실패: sagaId={}, error={}", sagaId, e.getMessage(), e);
-            
-            // 실패 응답 생성 (트랜잭션이 자동으로 롤백됨)
             return createFailureResponse(sagaId, command.getOrderId(), e.getMessage());
+        } catch (ArithmeticException e) {
+            log.error("번들 재고 예약 실패 (수량 계산 오버플로우): sagaId={}, error={}", sagaId, e.getMessage(), e);
+            return createFailureResponse(sagaId, command.getOrderId(), "요청 수량이 너무 많아 처리할 수 없습니다.");
         } catch (org.springframework.dao.OptimisticLockingFailureException e) {
             log.warn("번들 재고 예약 중 동시성 충돌 발생: sagaId={}, error={}", sagaId, e.getMessage());
             return createFailureResponse(sagaId, command.getOrderId(), "일시적인 오류가 발생했습니다. 다시 시도해주세요.");

--- a/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
+++ b/core/inventory-application/src/main/java/com/commerce/inventory/application/usecase/ReserveBundleStockService.java
@@ -45,15 +45,15 @@ public class ReserveBundleStockService implements ReserveBundleStockUseCase {
     @Override
     @Transactional
     public BundleReservationResponse execute(ReserveBundleStockCommand command) {
-        validateCommand(command);
-        
-        String sagaId = command.getSagaId();
-        
         try {
+            validateCommand(command);
+            String sagaId = command.getSagaId();
+            String orderId = command.getOrderId();
+
             // 1. 모든 개별 예약 요청 계산
             List<SkuReservationRequest> skuRequests = parseSkuRequests(command);
             if (skuRequests.isEmpty()) {
-                return createSuccessResponse(sagaId, command.getOrderId(), Collections.emptyList());
+                return createSuccessResponse(sagaId, orderId, Collections.emptyList());
             }
 
             // 2. 총 필요 수량 집계
@@ -66,17 +66,22 @@ public class ReserveBundleStockService implements ReserveBundleStockUseCase {
             List<Reservation> savedReservations = createAndSaveReservations(command, skuRequests, inventoryMap);
             
             // 5. 성공 응답 생성
-            return createSuccessResponse(sagaId, command.getOrderId(), savedReservations);
-            
+            return createSuccessResponse(sagaId, orderId, savedReservations);
+
+        } catch (IllegalArgumentException e) {
+            log.error("번들 재고 예약 실패 (잘못된 요청): {}", e.getMessage(), e);
+            String sagaId = (command != null) ? command.getSagaId() : null;
+            String orderId = (command != null) ? command.getOrderId() : null;
+            return createFailureResponse(sagaId, orderId, e.getMessage());
         } catch (InsufficientStockException | InvalidInventoryException e) {
-            log.error("번들 재고 예약 실패: sagaId={}, error={}", sagaId, e.getMessage(), e);
-            return createFailureResponse(sagaId, command.getOrderId(), e.getMessage());
+            log.error("번들 재고 예약 실패: sagaId={}, error={}", command.getSagaId(), e.getMessage(), e);
+            return createFailureResponse(command.getSagaId(), command.getOrderId(), e.getMessage());
         } catch (ArithmeticException e) {
-            log.error("번들 재고 예약 실패 (수량 계산 오버플로우): sagaId={}, error={}", sagaId, e.getMessage(), e);
-            return createFailureResponse(sagaId, command.getOrderId(), "요청 수량이 너무 많아 처리할 수 없습니다.");
+            log.error("번들 재고 예약 실패 (수량 계산 오버플로우): sagaId={}, error={}", command.getSagaId(), e.getMessage(), e);
+            return createFailureResponse(command.getSagaId(), command.getOrderId(), "요청 수량이 너무 많아 처리할 수 없습니다.");
         } catch (org.springframework.dao.OptimisticLockingFailureException e) {
-            log.warn("번들 재고 예약 중 동시성 충돌 발생: sagaId={}, error={}", sagaId, e.getMessage());
-            return createFailureResponse(sagaId, command.getOrderId(), "일시적인 오류가 발생했습니다. 다시 시도해주세요.");
+            log.warn("번들 재고 예약 중 동시성 충돌 발생: sagaId={}, error={}", command.getSagaId(), e.getMessage());
+            return createFailureResponse(command.getSagaId(), command.getOrderId(), "일시적인 오류가 발생했습니다. 다시 시도해주세요.");
         }
     }
 

--- a/core/inventory-application/src/test/java/com/commerce/inventory/application/usecase/ReserveBundleStockServiceTest.java
+++ b/core/inventory-application/src/test/java/com/commerce/inventory/application/usecase/ReserveBundleStockServiceTest.java
@@ -111,7 +111,7 @@ class ReserveBundleStockServiceTest {
             new SkuId("SKU-002"), inventory2
         );
         given(loadInventoryPort.loadAllByIds(anyList())).willReturn(inventoryMap);
-        given(reservationRepository.save(any(Reservation.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(reservationRepository.saveAll(anyList())).willAnswer(invocation -> invocation.getArgument(0));
 
         // When
         BundleReservationResponse response = sut.execute(command);
@@ -137,7 +137,7 @@ class ReserveBundleStockServiceTest {
 
         // 재고 저장 확인
         then(saveInventoryPort).should(times(1)).saveAll(anyCollection());
-        then(reservationRepository).should(times(2)).save(any(Reservation.class));
+        then(reservationRepository).should(times(1)).saveAll(anyList());
     }
 
     @Test
@@ -241,7 +241,7 @@ class ReserveBundleStockServiceTest {
             new SkuId("SKU-003"), inventory3
         );
         given(loadInventoryPort.loadAllByIds(anyList())).willReturn(inventoryMap);
-        given(reservationRepository.save(any(Reservation.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(reservationRepository.saveAll(anyList())).willAnswer(invocation -> invocation.getArgument(0));
 
         // When
         BundleReservationResponse response = sut.execute(command);
@@ -258,7 +258,7 @@ class ReserveBundleStockServiceTest {
         assertThat(sku001TotalQuantity).isEqualTo(2);
 
         then(saveInventoryPort).should(times(1)).saveAll(anyCollection());
-        then(reservationRepository).should(times(3)).save(any(Reservation.class));
+        then(reservationRepository).should(times(1)).saveAll(anyList());
     }
 
     @Test
@@ -305,7 +305,7 @@ class ReserveBundleStockServiceTest {
         
         // 사전 검증에서 실패하므로 save 메서드는 호출되지 않음
         then(saveInventoryPort).should(never()).saveAll(anyCollection());
-        then(reservationRepository).should(never()).save(any(Reservation.class));
+        then(reservationRepository).should(never()).saveAll(anyList());
     }
 
     @Test
@@ -366,7 +366,7 @@ class ReserveBundleStockServiceTest {
         // 실제 예약 로직이 실행되지 않아 save 메서드들이 호출되지 않음
         then(saveInventoryPort).should(never()).saveAll(anyCollection());
         then(saveInventoryPort).should(never()).save(any(Inventory.class));
-        then(reservationRepository).should(never()).save(any(Reservation.class));
+        then(reservationRepository).should(never()).saveAll(anyList());
     }
 
     @Test
@@ -396,7 +396,7 @@ class ReserveBundleStockServiceTest {
             new SkuId("SKU-001"), inventory
         );
         given(loadInventoryPort.loadAllByIds(anyList())).willReturn(inventoryMap);
-        given(reservationRepository.save(any(Reservation.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(reservationRepository.saveAll(anyList())).willAnswer(invocation -> invocation.getArgument(0));
 
         // When
         BundleReservationResponse response = sut.execute(command);
@@ -447,7 +447,7 @@ class ReserveBundleStockServiceTest {
             new SkuId("SKU-001"), inventory
         );
         given(loadInventoryPort.loadAllByIds(anyList())).willReturn(inventoryMap);
-        given(reservationRepository.save(any(Reservation.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(reservationRepository.saveAll(anyList())).willAnswer(invocation -> invocation.getArgument(0));
 
         // When
         BundleReservationResponse response = sut.execute(command);

--- a/core/inventory-application/src/test/java/com/commerce/inventory/application/usecase/ReserveBundleStockServiceTest.java
+++ b/core/inventory-application/src/test/java/com/commerce/inventory/application/usecase/ReserveBundleStockServiceTest.java
@@ -72,7 +72,7 @@ class ReserveBundleStockServiceTest {
     void reserveBundleStock_singleBundle_success() {
         // Given
         String orderId = "ORDER-001";
-        String reservationId = "BUNDLE-RESERVATION-001";
+        String sagaId = "BUNDLE-RESERVATION-001";
         
         ReserveBundleStockCommand.BundleItem bundleItem = ReserveBundleStockCommand.BundleItem.builder()
             .productOptionId("OPTION-001")
@@ -91,7 +91,7 @@ class ReserveBundleStockServiceTest {
 
         ReserveBundleStockCommand command = ReserveBundleStockCommand.builder()
             .orderId(orderId)
-            .reservationId(reservationId)
+            .sagaId(sagaId)
             .bundleItems(List.of(bundleItem))
             .ttlSeconds(900)
             .build();
@@ -118,7 +118,7 @@ class ReserveBundleStockServiceTest {
 
         // Then
         assertThat(response).isNotNull();
-        assertThat(response.getSagaId()).isEqualTo(reservationId);
+        assertThat(response.getSagaId()).isEqualTo(sagaId);
         assertThat(response.getOrderId()).isEqualTo(orderId);
         assertThat(response.getStatus()).isEqualTo(BundleReservationStatus.COMPLETED);
         assertThat(response.getSkuReservations()).hasSize(2);
@@ -161,7 +161,7 @@ class ReserveBundleStockServiceTest {
 
         ReserveBundleStockCommand command = ReserveBundleStockCommand.builder()
             .orderId("ORDER-001")
-            .reservationId("BUNDLE-RESERVATION-001")
+            .sagaId("BUNDLE-RESERVATION-001")
             .bundleItems(List.of(bundleItem))
             .ttlSeconds(900)
             .build();
@@ -225,7 +225,7 @@ class ReserveBundleStockServiceTest {
 
         ReserveBundleStockCommand command = ReserveBundleStockCommand.builder()
             .orderId("ORDER-001")
-            .reservationId("BUNDLE-RESERVATION-001")
+            .sagaId("BUNDLE-RESERVATION-001")
             .bundleItems(List.of(bundleItem1, bundleItem2))
             .ttlSeconds(900)
             .build();
@@ -282,7 +282,7 @@ class ReserveBundleStockServiceTest {
 
         ReserveBundleStockCommand command = ReserveBundleStockCommand.builder()
             .orderId("ORDER-001")
-            .reservationId("BUNDLE-RESERVATION-001")
+            .sagaId("BUNDLE-RESERVATION-001")
             .bundleItems(List.of(bundleItem))
             .ttlSeconds(900)
             .build();
@@ -333,7 +333,7 @@ class ReserveBundleStockServiceTest {
 
         ReserveBundleStockCommand command = ReserveBundleStockCommand.builder()
             .orderId("ORDER-001")
-            .reservationId("BUNDLE-RESERVATION-001")
+            .sagaId("BUNDLE-RESERVATION-001")
             .bundleItems(List.of(bundleItem))
             .ttlSeconds(900)
             .build();
@@ -375,7 +375,7 @@ class ReserveBundleStockServiceTest {
         // Given
         ReserveBundleStockCommand command = ReserveBundleStockCommand.builder()
             .orderId("ORDER-001")
-            .reservationId("BUNDLE-RESERVATION-001")
+            .sagaId("BUNDLE-RESERVATION-001")
             .bundleItems(List.of(
                 ReserveBundleStockCommand.BundleItem.builder()
                     .productOptionId("OPTION-001")
@@ -416,7 +416,7 @@ class ReserveBundleStockServiceTest {
         // Given
         ReserveBundleStockCommand command = ReserveBundleStockCommand.builder()
             .orderId("ORDER-001")
-            .reservationId("BUNDLE-RESERVATION-001")
+            .sagaId("BUNDLE-RESERVATION-001")
             .bundleItems(List.of(
                 ReserveBundleStockCommand.BundleItem.builder()
                     .productOptionId("OPTION-001")
@@ -476,7 +476,7 @@ class ReserveBundleStockServiceTest {
         // Given - empty order ID
         ReserveBundleStockCommand emptyOrderIdCommand = ReserveBundleStockCommand.builder()
             .orderId("")
-            .reservationId("BUNDLE-RESERVATION-001")
+            .sagaId("BUNDLE-RESERVATION-001")
             .bundleItems(List.of(ReserveBundleStockCommand.BundleItem.builder()
                 .productOptionId("OPTION-001")
                 .skuMappings(List.of(ReserveBundleStockCommand.SkuMapping.builder()
@@ -499,7 +499,7 @@ class ReserveBundleStockServiceTest {
         // Given - empty bundle items
         ReserveBundleStockCommand emptyItemsCommand = ReserveBundleStockCommand.builder()
             .orderId("ORDER-001")
-            .reservationId("BUNDLE-RESERVATION-001")
+            .sagaId("BUNDLE-RESERVATION-001")
             .bundleItems(List.of())
             .build();
         

--- a/core/inventory-application/src/test/java/com/commerce/inventory/application/usecase/ReserveBundleStockServiceTest.java
+++ b/core/inventory-application/src/test/java/com/commerce/inventory/application/usecase/ReserveBundleStockServiceTest.java
@@ -542,6 +542,6 @@ class ReserveBundleStockServiceTest {
 
         // Then
         assertThat(response.getStatus()).isEqualTo(BundleReservationStatus.FAILED);
-        assertThat(response.getFailureReason()).contains("integer overflow");
+        assertThat(response.getFailureReason()).isEqualTo("요청 수량이 너무 많아 처리할 수 없습니다.");
     }
 }

--- a/core/inventory-application/src/test/java/com/commerce/inventory/application/usecase/ReserveBundleStockServiceTest.java
+++ b/core/inventory-application/src/test/java/com/commerce/inventory/application/usecase/ReserveBundleStockServiceTest.java
@@ -282,20 +282,19 @@ class ReserveBundleStockServiceTest {
             new SkuId("SKU-001"), inventory1
         );
         given(loadInventoryPort.loadAllByIds(anyList())).willReturn(inventoryMap);
-        given(reservationRepository.save(any(Reservation.class))).willAnswer(invocation -> invocation.getArgument(0));
 
         // When
         BundleReservationResponse response = sut.execute(command);
 
         // Then
         assertThat(response.getStatus()).isEqualTo("FAILED");
-        assertThat(response.getFailureReason()).contains("재고를 찾을 수 없습니다");
+        assertThat(response.getFailureReason()).contains("다음 SKU에 대한 재고 정보를 찾을 수 없습니다");
+        assertThat(response.getFailureReason()).contains("SKU-NOT-EXIST");
         assertThat(response.getSkuReservations()).isEmpty();
         
-        // 트랜잭션 실패로 인해 saveInventoryPort.save()는 호출되지 않음
+        // 사전 검증에서 실패하므로 save 메서드는 호출되지 않음
         then(saveInventoryPort).should(never()).save(any(Inventory.class));
-        // 예외 발생 전 성공한 SKU에 대한 reservation save는 호출됨
-        then(reservationRepository).should(times(1)).save(any(Reservation.class));
+        then(reservationRepository).should(never()).save(any(Reservation.class));
     }
 
     @Test

--- a/core/inventory-application/src/test/java/com/commerce/inventory/application/usecase/ReserveBundleStockServiceTest.java
+++ b/core/inventory-application/src/test/java/com/commerce/inventory/application/usecase/ReserveBundleStockServiceTest.java
@@ -406,8 +406,7 @@ class ReserveBundleStockServiceTest {
         
         // 예약 만료 시간이 대략 900초 후인지 확인
         LocalDateTime expectedExpiry = LocalDateTime.now(fixedClock).plusSeconds(900);
-        assertThat(response.getSkuReservations().get(0).getExpiresAt())
-            .isBetween(expectedExpiry.minusSeconds(5), expectedExpiry.plusSeconds(5));
+        assertThat(response.getSkuReservations().get(0).getExpiresAt()).isEqualTo(expectedExpiry);
     }
 
     @Test

--- a/core/inventory-application/src/test/java/com/commerce/inventory/application/usecase/ReserveBundleStockServiceTest.java
+++ b/core/inventory-application/src/test/java/com/commerce/inventory/application/usecase/ReserveBundleStockServiceTest.java
@@ -54,7 +54,7 @@ class ReserveBundleStockServiceTest {
     void setUp() {
         // 고정된 시간으로 Clock 생성
         Instant fixedInstant = Instant.parse("2024-01-01T10:00:00Z");
-        fixedClock = Clock.fixed(fixedInstant, ZoneId.systemDefault());
+        fixedClock = Clock.fixed(fixedInstant, ZoneId.of("UTC"));
         
         sut = new ReserveBundleStockService(
             loadInventoryPort,

--- a/core/inventory-application/src/test/java/com/commerce/inventory/application/usecase/ReserveBundleStockServiceTest.java
+++ b/core/inventory-application/src/test/java/com/commerce/inventory/application/usecase/ReserveBundleStockServiceTest.java
@@ -313,8 +313,8 @@ class ReserveBundleStockServiceTest {
     }
 
     @Test
-    @DisplayName("예약 중 일부가 실패하면 트랜잭션이 롤백되어 전체 예약이 취소된다")
-    void reserveBundleStock_partialFailure_transactionRollback() {
+    @DisplayName("번들 내 SKU 중 하나라도 재고가 부족하면 전체 예약이 실패한다")
+    void reserveBundleStock_failWhenAnySkuInBundleIsInsufficient() {
         // Given
         ReserveBundleStockCommand.BundleItem bundleItem = ReserveBundleStockCommand.BundleItem.builder()
             .productOptionId("OPTION-001")

--- a/core/inventory-domain/src/main/java/com/commerce/inventory/domain/repository/ReservationRepository.java
+++ b/core/inventory-domain/src/main/java/com/commerce/inventory/domain/repository/ReservationRepository.java
@@ -18,4 +18,6 @@ public interface ReservationRepository extends Repository<Reservation, Reservati
     List<Reservation> findExpiredReservations(LocalDateTime currentTime);
     
     int deleteExpiredReservations(LocalDateTime currentTime);
+    
+    List<Reservation> saveAll(List<Reservation> reservations);
 }

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -86,7 +86,7 @@ PRD 문서와 설계 문서를 기반으로 수립한 구현 작업 계획입니
 - [x] CreateSkuUseCase
 - [x] ReceiveStockUseCase
 - [x] ReserveStockUseCase
-- [ ] ReserveBundleStockUseCase (Saga 패턴 기반)
+- [x] ReserveBundleStockUseCase (Saga 패턴 기반)
 - [x] ReleaseReservationUseCase
 - [x] GetInventoryUseCase
 

--- a/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
+++ b/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
@@ -9,6 +9,7 @@ import com.commerce.inventory.infrastructure.persistence.entity.InventoryJpaEnti
 import com.commerce.inventory.infrastructure.persistence.repository.InventoryJpaRepository;
 import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,7 +26,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class InventoryPersistenceAdapter implements LoadInventoryPort, SaveInventoryPort {
     
-    private static final int BATCH_SIZE = 1000;
+    @Value("${inventory.persistence.batch-size:1000}")
+    private int batchSize;
     
     private final InventoryJpaRepository inventoryJpaRepository;
     
@@ -48,8 +50,8 @@ public class InventoryPersistenceAdapter implements LoadInventoryPort, SaveInven
                 .map(SkuId::value)
                 .collect(Collectors.toList());
         
-        for (int i = 0; i < skuIdValues.size(); i += BATCH_SIZE) {
-            int endIndex = Math.min(i + BATCH_SIZE, skuIdValues.size());
+        for (int i = 0; i < skuIdValues.size(); i += batchSize) {
+            int endIndex = Math.min(i + batchSize, skuIdValues.size());
             List<String> batch = skuIdValues.subList(i, endIndex);
             
             Map<SkuId, Inventory> batchResult = inventoryJpaRepository.findAllById(batch).stream()

--- a/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
+++ b/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
@@ -27,6 +27,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class InventoryPersistenceAdapter implements LoadInventoryPort, SaveInventoryPort {
     
+    private static final int MAX_SKU_IDS_IN_ERROR_MESSAGE = 10;
+    
     @Value("${inventory.persistence.batch-size:1000}")
     private int batchSize;
     
@@ -110,9 +112,9 @@ public class InventoryPersistenceAdapter implements LoadInventoryPort, SaveInven
     private String formatConflictingSkuIds(Collection<Inventory> inventories) {
         String ids = inventories.stream()
                 .map(inv -> inv.getSkuId().value())
-                .limit(10)
+                .limit(MAX_SKU_IDS_IN_ERROR_MESSAGE)
                 .collect(Collectors.joining(", "));
-        if (inventories.size() > 10) {
+        if (inventories.size() > MAX_SKU_IDS_IN_ERROR_MESSAGE) {
             ids += " 등 (총 " + inventories.size() + "개)";
         }
         return "SKU IDs: " + ids;

--- a/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
+++ b/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
@@ -46,7 +46,7 @@ public class InventoryPersistenceAdapter implements LoadInventoryPort, SaveInven
                 .map(this::toDomainEntity)
                 .collect(Collectors.toMap(
                         Inventory::getSkuId,
-                        inventory -> inventory
+                        java.util.function.Function.identity()
                 ));
     }
     

--- a/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
+++ b/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
@@ -35,6 +35,9 @@ public class InventoryPersistenceAdapter implements LoadInventoryPort, SaveInven
     @Override
     @Transactional(readOnly = true)
     public Map<SkuId, Inventory> loadAllByIds(List<SkuId> skuIds) {
+        if (skuIds == null || skuIds.isEmpty()) {
+            return java.util.Collections.emptyMap();
+        }
         List<String> skuIdValues = skuIds.stream()
                 .map(SkuId::value)
                 .collect(Collectors.toList());
@@ -64,6 +67,9 @@ public class InventoryPersistenceAdapter implements LoadInventoryPort, SaveInven
     @Override
     @Transactional
     public void saveAll(Collection<Inventory> inventories) {
+        if (inventories == null || inventories.isEmpty()) {
+            return;
+        }
         try {
             List<InventoryJpaEntity> entities = inventories.stream()
                 .map(this::toJpaEntity)

--- a/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
+++ b/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
@@ -13,6 +13,7 @@ import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -55,6 +56,22 @@ public class InventoryPersistenceAdapter implements LoadInventoryPort, SaveInven
         } catch (OptimisticLockException e) {
             throw new OptimisticLockingFailureException(
                 "동시성 충돌이 발생했습니다. 다시 시도해주세요. SKU ID: " + inventory.getSkuId().value(), 
+                e
+            );
+        }
+    }
+    
+    @Override
+    @Transactional
+    public void saveAll(Collection<Inventory> inventories) {
+        try {
+            List<InventoryJpaEntity> entities = inventories.stream()
+                .map(this::toJpaEntity)
+                .collect(Collectors.toList());
+            inventoryJpaRepository.saveAll(entities);
+        } catch (OptimisticLockException e) {
+            throw new OptimisticLockingFailureException(
+                "동시성 충돌이 발생했습니다. 다시 시도해주세요.", 
                 e
             );
         }

--- a/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
+++ b/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
@@ -13,7 +13,10 @@ import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -26,6 +29,21 @@ public class InventoryPersistenceAdapter implements LoadInventoryPort, SaveInven
     public Optional<Inventory> load(SkuId skuId) {
         return inventoryJpaRepository.findById(skuId.value())
                 .map(this::toDomainEntity);
+    }
+    
+    @Override
+    @Transactional(readOnly = true)
+    public Map<SkuId, Inventory> loadAllByIds(List<SkuId> skuIds) {
+        List<String> skuIdValues = skuIds.stream()
+                .map(SkuId::value)
+                .collect(Collectors.toList());
+        
+        return inventoryJpaRepository.findAllById(skuIdValues).stream()
+                .map(this::toDomainEntity)
+                .collect(Collectors.toMap(
+                        Inventory::getSkuId,
+                        inventory -> inventory
+                ));
     }
     
     @Override

--- a/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
+++ b/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
@@ -54,12 +54,15 @@ public class InventoryPersistenceAdapter implements LoadInventoryPort, SaveInven
         if (skuIds == null || skuIds.isEmpty()) {
             return Map.of();
         }
+
+        // 중복된 SKU ID를 제거하여 불필요한 작업을 줄입니다.
+        List<SkuId> distinctSkuIds = skuIds.stream().distinct().collect(Collectors.toList());
         
-        Map<SkuId, Inventory> resultMap = new HashMap<>(skuIds.size());
+        Map<SkuId, Inventory> resultMap = new HashMap<>(distinctSkuIds.size());
         
-        for (int i = 0; i < skuIds.size(); i += batchSize) {
-            int endIndex = Math.min(i + batchSize, skuIds.size());
-            List<String> batchIds = skuIds.subList(i, endIndex).stream()
+        for (int i = 0; i < distinctSkuIds.size(); i += batchSize) {
+            int endIndex = Math.min(i + batchSize, distinctSkuIds.size());
+            List<String> batchIds = distinctSkuIds.subList(i, endIndex).stream()
                     .map(SkuId::value)
                     .collect(Collectors.toList());
             

--- a/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
+++ b/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
@@ -55,7 +55,7 @@ public class InventoryPersistenceAdapter implements LoadInventoryPort, SaveInven
             return Map.of();
         }
         
-        Map<SkuId, Inventory> resultMap = new HashMap<>();
+        Map<SkuId, Inventory> resultMap = new HashMap<>(skuIds.size());
         
         for (int i = 0; i < skuIds.size(); i += batchSize) {
             int endIndex = Math.min(i + batchSize, skuIds.size());

--- a/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
+++ b/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
@@ -73,7 +73,7 @@ public class InventoryPersistenceAdapter implements LoadInventoryPort, SaveInven
         try {
             InventoryJpaEntity entity = toJpaEntity(inventory);
             inventoryJpaRepository.save(entity);
-        } catch (OptimisticLockException e) {
+        } catch (OptimisticLockException | org.springframework.dao.OptimisticLockingFailureException e) {
             throw new OptimisticLockingFailureException(
                 "동시성 충돌이 발생했습니다. 다시 시도해주세요. SKU ID: " + inventory.getSkuId().value(), 
                 e
@@ -92,7 +92,7 @@ public class InventoryPersistenceAdapter implements LoadInventoryPort, SaveInven
                 .map(this::toJpaEntity)
                 .collect(Collectors.toList());
             inventoryJpaRepository.saveAll(entities);
-        } catch (OptimisticLockException e) {
+        } catch (OptimisticLockException | org.springframework.dao.OptimisticLockingFailureException e) {
             throw new OptimisticLockingFailureException(
                 "동시성 충돌이 발생했습니다. 다시 시도해주세요. " + formatConflictingSkuIds(inventories),
                 e

--- a/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
+++ b/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
@@ -91,18 +91,22 @@ public class InventoryPersistenceAdapter implements LoadInventoryPort, SaveInven
                 .collect(Collectors.toList());
             inventoryJpaRepository.saveAll(entities);
         } catch (OptimisticLockException e) {
-            String conflictingSkuIds = inventories.stream()
-                .map(inv -> inv.getSkuId().value())
-                .limit(10)
-                .collect(Collectors.joining(", "));
-            if (inventories.size() > 10) {
-                conflictingSkuIds += " 등 (총 " + inventories.size() + "개)";
-            }
             throw new OptimisticLockingFailureException(
-                "동시성 충돌이 발생했습니다. 다시 시도해주세요. SKU IDs: " + conflictingSkuIds,
+                "동시성 충돌이 발생했습니다. 다시 시도해주세요. " + formatConflictingSkuIds(inventories),
                 e
             );
         }
+    }
+    
+    private String formatConflictingSkuIds(Collection<Inventory> inventories) {
+        String ids = inventories.stream()
+                .map(inv -> inv.getSkuId().value())
+                .limit(10)
+                .collect(Collectors.joining(", "));
+        if (inventories.size() > 10) {
+            ids += " 등 (총 " + inventories.size() + "개)";
+        }
+        return "SKU IDs: " + ids;
     }
     
     private Inventory toDomainEntity(InventoryJpaEntity entity) {

--- a/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
+++ b/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
@@ -70,8 +70,11 @@ public class InventoryPersistenceAdapter implements LoadInventoryPort, SaveInven
                 .collect(Collectors.toList());
             inventoryJpaRepository.saveAll(entities);
         } catch (OptimisticLockException e) {
+            String conflictingSkuIds = inventories.stream()
+                .map(inv -> inv.getSkuId().value())
+                .collect(Collectors.joining(", "));
             throw new OptimisticLockingFailureException(
-                "동시성 충돌이 발생했습니다. 다시 시도해주세요.", 
+                "동시성 충돌이 발생했습니다. 다시 시도해주세요. SKU IDs: " + conflictingSkuIds,
                 e
             );
         }

--- a/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
+++ b/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
@@ -40,7 +40,7 @@ public class InventoryPersistenceAdapter implements LoadInventoryPort, SaveInven
     @Transactional(readOnly = true)
     public Map<SkuId, Inventory> loadAllByIds(List<SkuId> skuIds) {
         if (skuIds == null || skuIds.isEmpty()) {
-            return java.util.Collections.emptyMap();
+            return Map.of();
         }
         
         Map<SkuId, Inventory> resultMap = new HashMap<>();
@@ -56,7 +56,7 @@ public class InventoryPersistenceAdapter implements LoadInventoryPort, SaveInven
                     .map(this::toDomainEntity)
                     .collect(Collectors.toMap(
                             Inventory::getSkuId,
-                            java.util.function.Function.identity()
+                            inventory -> inventory
                     ));
             
             resultMap.putAll(batchResult);

--- a/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
+++ b/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapter.java
@@ -93,7 +93,11 @@ public class InventoryPersistenceAdapter implements LoadInventoryPort, SaveInven
         } catch (OptimisticLockException e) {
             String conflictingSkuIds = inventories.stream()
                 .map(inv -> inv.getSkuId().value())
+                .limit(10)
                 .collect(Collectors.joining(", "));
+            if (inventories.size() > 10) {
+                conflictingSkuIds += " 등 (총 " + inventories.size() + "개)";
+            }
             throw new OptimisticLockingFailureException(
                 "동시성 충돌이 발생했습니다. 다시 시도해주세요. SKU IDs: " + conflictingSkuIds,
                 e

--- a/infrastructure/inventory-persistence/src/test/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapterTest.java
+++ b/infrastructure/inventory-persistence/src/test/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapterTest.java
@@ -15,9 +15,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.OptimisticLockingFailureException;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -181,5 +185,144 @@ class InventoryPersistenceAdapterTest {
         assertThatThrownBy(() -> adapter.saveAll(inventories))
                 .isInstanceOf(OptimisticLockingFailureException.class)
                 .hasMessageContaining("동시성 충돌이 발생했습니다");
+    }
+    
+    @Test
+    @DisplayName("여러 SKU ID로 재고를 조회할 수 있다")
+    void shouldLoadAllInventoriesByIds() {
+        // given
+        SkuId skuId1 = SkuId.generate();
+        SkuId skuId2 = SkuId.generate();
+        SkuId skuId3 = SkuId.generate();
+        
+        InventoryJpaEntity entity1 = InventoryJpaEntity.builder()
+                .skuId(skuId1.value())
+                .totalQuantity(100)
+                .reservedQuantity(20)
+                .version(1L)
+                .build();
+                
+        InventoryJpaEntity entity2 = InventoryJpaEntity.builder()
+                .skuId(skuId2.value())
+                .totalQuantity(200)
+                .reservedQuantity(40)
+                .version(2L)
+                .build();
+        
+        List<SkuId> skuIds = Arrays.asList(skuId1, skuId2, skuId3);
+        List<String> skuIdValues = Arrays.asList(skuId1.value(), skuId2.value(), skuId3.value());
+        
+        when(inventoryJpaRepository.findAllById(skuIdValues))
+                .thenReturn(Arrays.asList(entity1, entity2));
+        
+        // when
+        Map<SkuId, Inventory> result = adapter.loadAllByIds(skuIds);
+        
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(skuId1)).isNotNull();
+        assertThat(result.get(skuId1).getTotalQuantity()).isEqualTo(Quantity.of(100));
+        assertThat(result.get(skuId2)).isNotNull();
+        assertThat(result.get(skuId2).getTotalQuantity()).isEqualTo(Quantity.of(200));
+        assertThat(result.get(skuId3)).isNull();
+    }
+    
+    @Test
+    @DisplayName("1000개 이상의 SKU ID로 조회 시 배치로 나누어 처리한다")
+    void shouldProcessInBatchesWhenLoadingMoreThan1000Ids() {
+        // given
+        List<SkuId> skuIds = IntStream.range(0, 2500)
+                .mapToObj(i -> SkuId.of("SKU-" + i))
+                .collect(Collectors.toList());
+        
+        // 첫 번째 배치 (0-999)
+        List<String> firstBatch = IntStream.range(0, 1000)
+                .mapToObj(i -> "SKU-" + i)
+                .collect(Collectors.toList());
+        List<InventoryJpaEntity> firstBatchEntities = IntStream.range(0, 1000)
+                .mapToObj(i -> InventoryJpaEntity.builder()
+                        .skuId("SKU-" + i)
+                        .totalQuantity(100 + i)
+                        .reservedQuantity(10)
+                        .version(1L)
+                        .build())
+                .collect(Collectors.toList());
+        
+        // 두 번째 배치 (1000-1999)
+        List<String> secondBatch = IntStream.range(1000, 2000)
+                .mapToObj(i -> "SKU-" + i)
+                .collect(Collectors.toList());
+        List<InventoryJpaEntity> secondBatchEntities = IntStream.range(1000, 2000)
+                .mapToObj(i -> InventoryJpaEntity.builder()
+                        .skuId("SKU-" + i)
+                        .totalQuantity(100 + i)
+                        .reservedQuantity(10)
+                        .version(1L)
+                        .build())
+                .collect(Collectors.toList());
+        
+        // 세 번째 배치 (2000-2499)
+        List<String> thirdBatch = IntStream.range(2000, 2500)
+                .mapToObj(i -> "SKU-" + i)
+                .collect(Collectors.toList());
+        List<InventoryJpaEntity> thirdBatchEntities = IntStream.range(2000, 2500)
+                .mapToObj(i -> InventoryJpaEntity.builder()
+                        .skuId("SKU-" + i)
+                        .totalQuantity(100 + i)
+                        .reservedQuantity(10)
+                        .version(1L)
+                        .build())
+                .collect(Collectors.toList());
+        
+        when(inventoryJpaRepository.findAllById(firstBatch))
+                .thenReturn(firstBatchEntities);
+        when(inventoryJpaRepository.findAllById(secondBatch))
+                .thenReturn(secondBatchEntities);
+        when(inventoryJpaRepository.findAllById(thirdBatch))
+                .thenReturn(thirdBatchEntities);
+        
+        // when
+        Map<SkuId, Inventory> result = adapter.loadAllByIds(skuIds);
+        
+        // then
+        assertThat(result).hasSize(2500);
+        verify(inventoryJpaRepository, times(3)).findAllById(anyList());
+        
+        // 각 배치가 올바른 크기로 호출되었는지 확인
+        ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
+        verify(inventoryJpaRepository, times(3)).findAllById(captor.capture());
+        List<List<String>> allBatches = captor.getAllValues();
+        
+        assertThat(allBatches.get(0)).hasSize(1000);
+        assertThat(allBatches.get(1)).hasSize(1000);
+        assertThat(allBatches.get(2)).hasSize(500);
+        
+        // 결과 검증
+        assertThat(result.get(SkuId.of("SKU-0")).getTotalQuantity()).isEqualTo(Quantity.of(100));
+        assertThat(result.get(SkuId.of("SKU-999")).getTotalQuantity()).isEqualTo(Quantity.of(1099));
+        assertThat(result.get(SkuId.of("SKU-1000")).getTotalQuantity()).isEqualTo(Quantity.of(1100));
+        assertThat(result.get(SkuId.of("SKU-2499")).getTotalQuantity()).isEqualTo(Quantity.of(2599));
+    }
+    
+    @Test
+    @DisplayName("빈 리스트로 조회 시 빈 맵을 반환한다")
+    void shouldReturnEmptyMapWhenLoadingWithEmptyList() {
+        // when
+        Map<SkuId, Inventory> result = adapter.loadAllByIds(new ArrayList<>());
+        
+        // then
+        assertThat(result).isEmpty();
+        verify(inventoryJpaRepository, never()).findAllById(anyList());
+    }
+    
+    @Test
+    @DisplayName("null 리스트로 조회 시 빈 맵을 반환한다")
+    void shouldReturnEmptyMapWhenLoadingWithNullList() {
+        // when
+        Map<SkuId, Inventory> result = adapter.loadAllByIds(null);
+        
+        // then
+        assertThat(result).isEmpty();
+        verify(inventoryJpaRepository, never()).findAllById(anyList());
     }
 }

--- a/infrastructure/inventory-persistence/src/test/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapterTest.java
+++ b/infrastructure/inventory-persistence/src/test/java/com/commerce/inventory/infrastructure/persistence/adapter/InventoryPersistenceAdapterTest.java
@@ -14,6 +14,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,6 +42,8 @@ class InventoryPersistenceAdapterTest {
     @BeforeEach
     void setUp() {
         adapter = new InventoryPersistenceAdapter(inventoryJpaRepository);
+        // 테스트용 배치 크기 설정
+        ReflectionTestUtils.setField(adapter, "batchSize", 1000);
     }
     
     @Test


### PR DESCRIPTION
## 작업 내용
docs/ 폴더의 설계문서를 참고하여 IMPLEMENTATION_PLAN.md에서 정리한 작업 중 5.1 Inventory UseCase의 ReserveBundleStockUseCase를 구현했습니다.

## 구현 내용
- 번들 상품의 재고 예약을 처리하는 UseCase 구현
- 여러 SKU를 포함하는 번들 상품의 재고를 일괄 예약
- 예약 실패 시 롤백 처리 구현
- 트랜잭션 단위로 원자성 보장

## 변경 사항
- `ReserveBundleStockUseCase` 인터페이스 정의
- `ReserveBundleStockCommand` DTO 클래스 구현
- `BundleReservationResponse` DTO 클래스 구현
- `ReserveBundleStockService` 구현체 작성
- TDD 방식으로 테스트 코드 작성

## 테스트
- 단일 번들 상품 예약 성공 케이스
- 재고 부족 시 실패 케이스
- 여러 번들 동시 예약 케이스
- SKU 미존재 시 실패 케이스
- 부분 실패 시 롤백 케이스
- 동일 SKU 중복 예약 케이스
- 입력값 검증 케이스

모든 테스트가 성공적으로 통과했습니다.

Closes #29