### PR TITLE
Product UseCase 의 GetProductUseCase 구현

### DIFF
--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/GetProductRequest.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/GetProductRequest.java
@@ -1,0 +1,8 @@
+package com.commerce.product.application.usecase;
+
+import lombok.Value;
+
+@Value
+public class GetProductRequest {
+    String productId;
+}

--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/GetProductResponse.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/GetProductResponse.java
@@ -1,0 +1,38 @@
+package com.commerce.product.application.usecase;
+
+import com.commerce.product.domain.model.ProductStatus;
+import com.commerce.product.domain.model.ProductType;
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.List;
+
+@Value
+@Builder
+public class GetProductResponse {
+    String productId;
+    String name;
+    String description;
+    ProductType type;
+    ProductStatus status;
+    List<ProductOptionResponse> options;
+    
+    @Value
+    @Builder
+    public static class ProductOptionResponse {
+        String optionId;
+        String name;
+        long price;
+        String currency;
+        List<SkuMappingResponse> skuMappings;
+        boolean isAvailable;
+        int availableQuantity;
+    }
+    
+    @Value
+    @Builder
+    public static class SkuMappingResponse {
+        String skuId;
+        int quantity;
+    }
+}

--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/GetProductService.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/GetProductService.java
@@ -1,0 +1,93 @@
+package com.commerce.product.application.usecase;
+
+import com.commerce.product.domain.model.*;
+import com.commerce.product.domain.repository.ProductRepository;
+import com.commerce.product.domain.service.StockAvailabilityService;
+import com.commerce.product.domain.service.result.AvailabilityResult;
+import com.commerce.product.domain.service.result.BundleAvailabilityResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class GetProductService implements GetProductUseCase {
+    
+    private final ProductRepository productRepository;
+    private final StockAvailabilityService stockAvailabilityService;
+    
+    @Override
+    public GetProductResponse execute(GetProductRequest request) {
+        log.info("Getting product: {}", request.getProductId());
+        
+        ProductId productId = new ProductId(request.getProductId());
+        Product product = productRepository.findById(productId)
+            .orElseThrow(() -> new IllegalArgumentException("Product not found: " + request.getProductId()));
+        
+        List<GetProductResponse.ProductOptionResponse> optionResponses = new ArrayList<>();
+        
+        for (ProductOption option : product.getOptions()) {
+            GetProductResponse.ProductOptionResponse optionResponse = buildOptionResponse(option, product.getType());
+            optionResponses.add(optionResponse);
+        }
+        
+        return GetProductResponse.builder()
+            .productId(product.getId().value())
+            .name(product.getName().value())
+            .description(product.getDescription())
+            .type(product.getType())
+            .status(product.getStatus())
+            .options(optionResponses)
+            .build();
+    }
+    
+    private GetProductResponse.ProductOptionResponse buildOptionResponse(ProductOption option, ProductType productType) {
+        boolean isAvailable = false;
+        int availableQuantity = 0;
+        
+        try {
+            if (productType == ProductType.BUNDLE && option.isBundle()) {
+                // 묶음 상품 재고 확인
+                CompletableFuture<BundleAvailabilityResult> future = 
+                    stockAvailabilityService.checkBundleAvailability(option.getSkuMapping());
+                BundleAvailabilityResult result = future.get(5, TimeUnit.SECONDS);
+                isAvailable = result.isAvailable();
+                availableQuantity = result.availableSets();
+            } else {
+                // 일반 상품 재고 확인
+                CompletableFuture<AvailabilityResult> future = 
+                    stockAvailabilityService.checkProductOptionAvailability(option.getId());
+                AvailabilityResult result = future.get(5, TimeUnit.SECONDS);
+                isAvailable = result.isAvailable();
+                availableQuantity = result.availableQuantity();
+            }
+        } catch (Exception e) {
+            log.error("Failed to check stock availability for option: {}", option.getId(), e);
+            // 재고 확인 실패 시 기본값 유지 (재고 없음)
+        }
+        
+        List<GetProductResponse.SkuMappingResponse> skuMappingResponses = option.getSkuMapping().mappings().entrySet().stream()
+            .map(entry -> GetProductResponse.SkuMappingResponse.builder()
+                .skuId(entry.getKey())
+                .quantity(entry.getValue())
+                .build())
+            .collect(Collectors.toList());
+        
+        return GetProductResponse.ProductOptionResponse.builder()
+            .optionId(option.getId())
+            .name(option.getName())
+            .price(option.getPrice().amount().longValue())
+            .currency(option.getPrice().currency().name())
+            .skuMappings(skuMappingResponses)
+            .isAvailable(isAvailable)
+            .availableQuantity(availableQuantity)
+            .build();
+    }
+}

--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/GetProductUseCase.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/GetProductUseCase.java
@@ -1,0 +1,5 @@
+package com.commerce.product.application.usecase;
+
+public interface GetProductUseCase {
+    GetProductResponse execute(GetProductRequest request);
+}

--- a/core/product-core/src/main/java/com/commerce/product/domain/model/Money.java
+++ b/core/product-core/src/main/java/com/commerce/product/domain/model/Money.java
@@ -23,6 +23,14 @@ public record Money(BigDecimal amount, Currency currency) implements ValueObject
     public static Money of(BigDecimal amount, Currency currency) {
         return new Money(amount, currency);
     }
+    
+    public static Money of(long amount) {
+        return new Money(BigDecimal.valueOf(amount), Currency.KRW);
+    }
+    
+    public static Money of(long amount, Currency currency) {
+        return new Money(BigDecimal.valueOf(amount), currency);
+    }
 
     private static void validate(BigDecimal amount) {
         if (amount == null) {

--- a/core/product-core/src/main/java/com/commerce/product/domain/model/Product.java
+++ b/core/product-core/src/main/java/com/commerce/product/domain/model/Product.java
@@ -57,6 +57,18 @@ public class Product extends AggregateRoot<ProductId> {
         
         return product;
     }
+    
+    public static Product create(ProductId id, ProductName name, String description, ProductType type, ProductStatus status) {
+        validateCreation(name, type);
+        
+        String validDescription = description != null ? description : "";
+        
+        Product product = new Product(id, name, validDescription, type);
+        product.status = status;
+        product.addDomainEvent(new ProductCreatedEvent(id, name.value(), type));
+        
+        return product;
+    }
 
     private static void validateCreation(ProductName name, ProductType type) {
         if (name == null) {

--- a/core/product-core/src/main/java/com/commerce/product/domain/model/ProductId.java
+++ b/core/product-core/src/main/java/com/commerce/product/domain/model/ProductId.java
@@ -14,6 +14,10 @@ public record ProductId(String value) implements ValueObject {
     public static ProductId generate() {
         return new ProductId(UUID.randomUUID().toString());
     }
+    
+    public static ProductId of(String value) {
+        return new ProductId(value);
+    }
 
     private static void validate(String value) {
         if (value == null || value.trim().isEmpty()) {

--- a/core/product-core/src/main/java/com/commerce/product/domain/model/ProductName.java
+++ b/core/product-core/src/main/java/com/commerce/product/domain/model/ProductName.java
@@ -9,6 +9,10 @@ public record ProductName(String value) implements ValueObject {
     public ProductName {
         validate(value);
     }
+    
+    public static ProductName of(String value) {
+        return new ProductName(value);
+    }
 
     private static void validate(String value) {
         if (value == null || value.trim().isEmpty()) {

--- a/core/product-core/src/test/java/com/commerce/product/application/usecase/GetProductUseCaseTest.java
+++ b/core/product-core/src/test/java/com/commerce/product/application/usecase/GetProductUseCaseTest.java
@@ -1,0 +1,215 @@
+package com.commerce.product.application.usecase;
+
+import com.commerce.product.domain.model.*;
+import com.commerce.product.domain.repository.ProductRepository;
+import com.commerce.product.domain.service.StockAvailabilityService;
+import com.commerce.product.domain.service.result.AvailabilityResult;
+import com.commerce.product.domain.service.result.BundleAvailabilityResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetProductUseCase 테스트")
+class GetProductUseCaseTest {
+    
+    @Mock
+    private ProductRepository productRepository;
+    
+    @Mock
+    private StockAvailabilityService stockAvailabilityService;
+    
+    private GetProductUseCase getProductUseCase;
+    
+    @BeforeEach
+    void setUp() {
+        getProductUseCase = new GetProductService(productRepository, stockAvailabilityService);
+    }
+    
+    @Nested
+    @DisplayName("상품 조회 시")
+    class GetProductTest {
+        
+        @Test
+        @DisplayName("존재하는 상품ID로 조회하면 상품 정보를 반환한다")
+        void should_return_product_when_product_exists() {
+            // Given
+            ProductId productId = ProductId.of("550e8400-e29b-41d4-a716-446655440001");
+            Product product = createNormalProduct(productId);
+            given(productRepository.findById(productId)).willReturn(Optional.of(product));
+            
+            // 재고 조회 Mock
+            given(stockAvailabilityService.checkProductOptionAvailability(any()))
+                .willReturn(CompletableFuture.completedFuture(createAvailableResult()));
+            
+            // When
+            GetProductResponse response = getProductUseCase.execute(new GetProductRequest(productId.value()));
+            
+            // Then
+            assertThat(response).isNotNull();
+            assertThat(response.getProductId()).isEqualTo(productId.value());
+            assertThat(response.getName()).isEqualTo("테스트 상품");
+            assertThat(response.getType()).isEqualTo(ProductType.NORMAL);
+            assertThat(response.getStatus()).isEqualTo(ProductStatus.ACTIVE);
+            assertThat(response.getOptions()).hasSize(1);
+            
+            // 재고 확인이 호출되었는지 검증
+            verify(stockAvailabilityService, times(1)).checkProductOptionAvailability(any());
+        }
+        
+        @Test
+        @DisplayName("존재하지 않는 상품ID로 조회하면 예외가 발생한다")
+        void should_throw_exception_when_product_not_exists() {
+            // Given
+            ProductId productId = ProductId.of("550e8400-e29b-41d4-a716-446655440002");
+            given(productRepository.findById(productId)).willReturn(Optional.empty());
+            
+            // When & Then
+            assertThatThrownBy(() -> getProductUseCase.execute(new GetProductRequest(productId.value())))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Product not found: " + productId.value());
+        }
+        
+        @Test
+        @DisplayName("묶음 상품 조회 시 묶음 재고를 확인한다")
+        void should_check_bundle_availability_for_bundle_product() {
+            // Given
+            ProductId productId = ProductId.of("550e8400-e29b-41d4-a716-446655440003");
+            Product bundleProduct = createBundleProduct(productId);
+            given(productRepository.findById(productId)).willReturn(Optional.of(bundleProduct));
+            
+            // 묶음 재고 조회 Mock
+            given(stockAvailabilityService.checkBundleAvailability(any(SkuMapping.class)))
+                .willReturn(CompletableFuture.completedFuture(createBundleAvailableResult()));
+            
+            // When
+            GetProductResponse response = getProductUseCase.execute(new GetProductRequest(productId.value()));
+            
+            // Then
+            assertThat(response).isNotNull();
+            assertThat(response.getType()).isEqualTo(ProductType.BUNDLE);
+            assertThat(response.getOptions()).hasSize(1);
+            assertThat(response.getOptions().get(0).getAvailableQuantity()).isEqualTo(10);
+            
+            // 묶음 재고 확인이 호출되었는지 검증
+            verify(stockAvailabilityService, times(1)).checkBundleAvailability(any(SkuMapping.class));
+        }
+        
+        @Test
+        @DisplayName("재고가 없는 상품은 가용 수량이 0으로 표시된다")
+        void should_show_zero_quantity_when_out_of_stock() {
+            // Given
+            ProductId productId = ProductId.of("550e8400-e29b-41d4-a716-446655440001");
+            Product product = createNormalProduct(productId);
+            given(productRepository.findById(productId)).willReturn(Optional.of(product));
+            
+            // 재고 없음 Mock
+            given(stockAvailabilityService.checkProductOptionAvailability(any()))
+                .willReturn(CompletableFuture.completedFuture(createOutOfStockResult()));
+            
+            // When
+            GetProductResponse response = getProductUseCase.execute(new GetProductRequest(productId.value()));
+            
+            // Then
+            assertThat(response.getOptions().get(0).getAvailableQuantity()).isEqualTo(0);
+            assertThat(response.getOptions().get(0).isAvailable()).isFalse();
+        }
+        
+        @Test
+        @DisplayName("재고 조회 실패 시에도 상품 정보는 반환한다")
+        void should_return_product_info_even_when_stock_check_fails() {
+            // Given
+            ProductId productId = ProductId.of("550e8400-e29b-41d4-a716-446655440001");
+            Product product = createNormalProduct(productId);
+            given(productRepository.findById(productId)).willReturn(Optional.of(product));
+            
+            // 재고 조회 실패 Mock
+            given(stockAvailabilityService.checkProductOptionAvailability(any()))
+                .willReturn(CompletableFuture.failedFuture(new RuntimeException("Stock service error")));
+            
+            // When
+            GetProductResponse response = getProductUseCase.execute(new GetProductRequest(productId.value()));
+            
+            // Then
+            assertThat(response).isNotNull();
+            assertThat(response.getProductId()).isEqualTo(productId.value());
+            assertThat(response.getOptions().get(0).getAvailableQuantity()).isEqualTo(0);
+            assertThat(response.getOptions().get(0).isAvailable()).isFalse();
+        }
+    }
+    
+    private Product createNormalProduct(ProductId productId) {
+        Product product = Product.create(
+            productId,
+            ProductName.of("테스트 상품"),
+            "테스트 상품 설명",
+            ProductType.NORMAL,
+            ProductStatus.ACTIVE
+        );
+        
+        ProductOption option = ProductOption.single(
+            "기본 옵션",
+            Money.of(10000),
+            "SKU001"
+        );
+        
+        product.addOption(option);
+        return product;
+    }
+    
+    private Product createBundleProduct(ProductId productId) {
+        Product product = Product.create(
+            productId,
+            ProductName.of("묶음 상품"),
+            "묶음 상품 설명",
+            ProductType.BUNDLE,
+            ProductStatus.ACTIVE
+        );
+        
+        Map<String, Integer> bundleMappings = new HashMap<>();
+        bundleMappings.put("SKU001", 2);
+        bundleMappings.put("SKU002", 1);
+        
+        SkuMapping bundleSkuMapping = SkuMapping.bundle(bundleMappings);
+        
+        ProductOption bundleOption = ProductOption.bundle(
+            "묶음 옵션",
+            Money.of(25000),
+            bundleSkuMapping
+        );
+        
+        product.addOption(bundleOption);
+        return product;
+    }
+    
+    private AvailabilityResult createAvailableResult() {
+        return new AvailabilityResult(true, 100);
+    }
+    
+    private AvailabilityResult createOutOfStockResult() {
+        return new AvailabilityResult(false, 0);
+    }
+    
+    private BundleAvailabilityResult createBundleAvailableResult() {
+        List<BundleAvailabilityResult.SkuAvailabilityDetail> details = Arrays.asList(
+            new BundleAvailabilityResult.SkuAvailabilityDetail("SKU001", 2, 30, 15),
+            new BundleAvailabilityResult.SkuAvailabilityDetail("SKU002", 1, 20, 20)
+        );
+        
+        return BundleAvailabilityResult.available(10, details);
+    }
+}

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -94,7 +94,7 @@ PRD 문서와 설계 문서를 기반으로 수립한 구현 작업 계획입니
 - [x] CreateProductUseCase
 - [x] UpdateProductUseCase
 - [x] AddProductOptionUseCase
-- [ ] GetProductUseCase
+- [x] GetProductUseCase
 - [ ] SearchProductsUseCase
 
 #### 5.3 Category UseCase


### PR DESCRIPTION
## 작업 내용

GetProductUseCase를 TDD 방식으로 구현했습니다.

### 구현 사항
- ✅ GetProductUseCase 인터페이스 및 구현체(GetProductService) 추가
- ✅ GetProductRequest/Response DTO 구현
- ✅ 상품 조회 시 재고 가용성 확인 기능 포함
- ✅ 묶음 상품과 일반 상품 구분하여 재고 확인
- ✅ 재고 서비스 호출 실패 시에도 상품 정보 반환

### 추가 변경사항
- ProductId, ProductName, Money에 편의 메서드 추가 (`of()` 메서드)
- Product.create() 오버로드 메서드 추가 (테스트용)

### 테스트
- TDD 방식으로 테스트 코드 먼저 작성 후 구현
- 모든 테스트 통과 확인

### IMPLEMENTATION_PLAN.md 업데이트
- GetProductUseCase 완료 표시

Closes #38