### PR TITLE
feat: Category UseCase의 CreateCategoryUseCase 구현

### DIFF
--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/CreateCategoryRequest.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/CreateCategoryRequest.java
@@ -1,0 +1,21 @@
+package com.commerce.product.application.usecase;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 카테고리 생성 요청 DTO
+ */
+@Getter
+@Builder
+public class CreateCategoryRequest {
+    private final String name;
+    private final String parentId;
+    private final int sortOrder;
+    
+    public CreateCategoryRequest(String name, String parentId, int sortOrder) {
+        this.name = name;
+        this.parentId = parentId;
+        this.sortOrder = sortOrder;
+    }
+}

--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/CreateCategoryResponse.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/CreateCategoryResponse.java
@@ -1,0 +1,30 @@
+package com.commerce.product.application.usecase;
+
+import com.commerce.product.domain.model.Category;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 카테고리 생성 응답 DTO
+ */
+@Getter
+@Builder
+public class CreateCategoryResponse {
+    private final String id;
+    private final String name;
+    private final String parentId;
+    private final int level;
+    private final int sortOrder;
+    private final boolean isActive;
+    
+    public static CreateCategoryResponse from(Category category) {
+        return CreateCategoryResponse.builder()
+                .id(category.getId().value())
+                .name(category.getName().value())
+                .parentId(category.getParentId() != null ? category.getParentId().value() : null)
+                .level(category.getLevel())
+                .sortOrder(category.getSortOrder())
+                .isActive(category.isActive())
+                .build();
+    }
+}

--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/CreateCategoryService.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/CreateCategoryService.java
@@ -1,0 +1,95 @@
+package com.commerce.product.application.usecase;
+
+import com.commerce.product.domain.model.Category;
+import com.commerce.product.domain.model.CategoryId;
+import com.commerce.product.domain.model.CategoryName;
+import com.commerce.product.domain.repository.CategoryRepository;
+import com.commerce.product.domain.exception.InvalidCategoryLevelException;
+import com.commerce.product.domain.exception.InvalidCategoryNameException;
+import com.commerce.product.domain.exception.ProductDomainException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.UUID;
+
+/**
+ * 카테고리 생성 UseCase 구현체
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CreateCategoryService implements CreateCategoryUseCase {
+    
+    private final CategoryRepository categoryRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    
+    @Override
+    public CreateCategoryResponse createCategory(CreateCategoryRequest request) {
+        validateRequest(request);
+        
+        Category category;
+        
+        if (request.getParentId() == null) {
+            // 루트 카테고리 생성
+            category = createRootCategory(request);
+        } else {
+            // 하위 카테고리 생성
+            category = createChildCategory(request);
+        }
+        
+        Category savedCategory = categoryRepository.save(category);
+        
+        // 도메인 이벤트 발행
+        publishDomainEvents(savedCategory);
+        
+        return CreateCategoryResponse.from(savedCategory);
+    }
+    
+    private void validateRequest(CreateCategoryRequest request) {
+        // 이름 검증
+        if (request.getName() == null || request.getName().trim().isEmpty()) {
+            throw new InvalidCategoryNameException("Category name cannot be null or empty");
+        }
+        
+        if (request.getName().length() > 100) {
+            throw new InvalidCategoryNameException("Category name cannot exceed 100 characters");
+        }
+        
+        // 정렬 순서 검증
+        if (request.getSortOrder() < 0) {
+            throw new IllegalArgumentException("Sort order must be positive");
+        }
+    }
+    
+    private Category createRootCategory(CreateCategoryRequest request) {
+        CategoryId categoryId = new CategoryId(UUID.randomUUID().toString());
+        CategoryName categoryName = new CategoryName(request.getName());
+        
+        return Category.createRoot(categoryId, categoryName, request.getSortOrder());
+    }
+    
+    private Category createChildCategory(CreateCategoryRequest request) {
+        CategoryId parentId = new CategoryId(request.getParentId());
+        
+        // 부모 카테고리 조회
+        Category parentCategory = categoryRepository.findById(parentId)
+                .orElseThrow(() -> new ProductDomainException("Parent category not found: " + request.getParentId()));
+        
+        // 레벨 확인 (부모가 3레벨이면 자식을 생성할 수 없음)
+        if (parentCategory.getLevel() >= 3) {
+            throw new InvalidCategoryLevelException("Maximum category level is 3");
+        }
+        
+        CategoryId categoryId = new CategoryId(UUID.randomUUID().toString());
+        CategoryName categoryName = new CategoryName(request.getName());
+        int childLevel = parentCategory.getLevel() + 1;
+        
+        return Category.createChild(categoryId, categoryName, parentId, childLevel, request.getSortOrder());
+    }
+    
+    private void publishDomainEvents(Category category) {
+        category.pullDomainEvents().forEach(eventPublisher::publishEvent);
+    }
+}

--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/CreateCategoryUseCase.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/CreateCategoryUseCase.java
@@ -1,0 +1,8 @@
+package com.commerce.product.application.usecase;
+
+/**
+ * 카테고리 생성 UseCase 인터페이스
+ */
+public interface CreateCategoryUseCase {
+    CreateCategoryResponse createCategory(CreateCategoryRequest request);
+}

--- a/core/product-core/src/test/java/com/commerce/product/application/usecase/CreateCategoryUseCaseTest.java
+++ b/core/product-core/src/test/java/com/commerce/product/application/usecase/CreateCategoryUseCaseTest.java
@@ -1,0 +1,304 @@
+package com.commerce.product.application.usecase;
+
+import com.commerce.product.domain.model.Category;
+import com.commerce.product.domain.model.CategoryId;
+import com.commerce.product.domain.model.CategoryName;
+import com.commerce.product.domain.repository.CategoryRepository;
+import com.commerce.product.domain.exception.InvalidCategoryIdException;
+import com.commerce.product.domain.exception.InvalidCategoryNameException;
+import com.commerce.product.domain.exception.InvalidCategoryLevelException;
+import com.commerce.product.domain.exception.ProductDomainException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CreateCategoryUseCase 테스트")
+class CreateCategoryUseCaseTest {
+
+    @InjectMocks
+    private CreateCategoryService createCategoryService;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private CreateCategoryRequest request;
+
+    @BeforeEach
+    void setUp() {
+        request = null;
+    }
+
+    @Test
+    @DisplayName("루트 카테고리를 생성할 수 있다")
+    void should_create_root_category() {
+        // Given
+        String categoryId = UUID.randomUUID().toString();
+        request = CreateCategoryRequest.builder()
+                .name("전자제품")
+                .parentId(null)
+                .sortOrder(1)
+                .build();
+
+        Category expectedCategory = Category.createRoot(
+                new CategoryId(categoryId),
+                new CategoryName("전자제품"),
+                1
+        );
+        
+        when(categoryRepository.save(any(Category.class))).thenReturn(expectedCategory);
+
+        // When
+        CreateCategoryResponse response = createCategoryService.createCategory(request);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getName()).isEqualTo("전자제품");
+        assertThat(response.getParentId()).isNull();
+        assertThat(response.getLevel()).isEqualTo(1);
+        assertThat(response.getSortOrder()).isEqualTo(1);
+        assertThat(response.isActive()).isTrue();
+        
+        verify(categoryRepository, times(1)).save(any(Category.class));
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("하위 카테고리를 생성할 수 있다")
+    void should_create_child_category() {
+        // Given
+        String parentId = UUID.randomUUID().toString();
+        String categoryId = UUID.randomUUID().toString();
+        
+        Category parentCategory = Category.createRoot(
+                new CategoryId(parentId),
+                new CategoryName("전자제품"),
+                1
+        );
+        
+        request = CreateCategoryRequest.builder()
+                .name("노트북")
+                .parentId(parentId)
+                .sortOrder(1)
+                .build();
+
+        Category expectedCategory = Category.createChild(
+                new CategoryId(categoryId),
+                new CategoryName("노트북"),
+                new CategoryId(parentId),
+                2,
+                1
+        );
+        
+        when(categoryRepository.findById(new CategoryId(parentId)))
+                .thenReturn(Optional.of(parentCategory));
+        when(categoryRepository.save(any(Category.class))).thenReturn(expectedCategory);
+
+        // When
+        CreateCategoryResponse response = createCategoryService.createCategory(request);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getName()).isEqualTo("노트북");
+        assertThat(response.getParentId()).isEqualTo(parentId);
+        assertThat(response.getLevel()).isEqualTo(2);
+        assertThat(response.getSortOrder()).isEqualTo(1);
+        assertThat(response.isActive()).isTrue();
+        
+        verify(categoryRepository, times(1)).findById(new CategoryId(parentId));
+        verify(categoryRepository, times(1)).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("3단계 하위 카테고리를 생성할 수 있다")
+    void should_create_third_level_category() {
+        // Given
+        String rootId = UUID.randomUUID().toString();
+        String parentId = UUID.randomUUID().toString();
+        String categoryId = UUID.randomUUID().toString();
+        
+        Category secondLevelCategory = Category.createChild(
+                new CategoryId(parentId),
+                new CategoryName("노트북"),
+                new CategoryId(rootId),
+                2,
+                1
+        );
+        
+        request = CreateCategoryRequest.builder()
+                .name("게이밍 노트북")
+                .parentId(parentId)
+                .sortOrder(1)
+                .build();
+
+        Category expectedCategory = Category.createChild(
+                new CategoryId(categoryId),
+                new CategoryName("게이밍 노트북"),
+                new CategoryId(parentId),
+                3,
+                1
+        );
+        
+        when(categoryRepository.findById(new CategoryId(parentId)))
+                .thenReturn(Optional.of(secondLevelCategory));
+        when(categoryRepository.save(any(Category.class))).thenReturn(expectedCategory);
+
+        // When
+        CreateCategoryResponse response = createCategoryService.createCategory(request);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getName()).isEqualTo("게이밍 노트북");
+        assertThat(response.getParentId()).isEqualTo(parentId);
+        assertThat(response.getLevel()).isEqualTo(3);
+        assertThat(response.getSortOrder()).isEqualTo(1);
+        assertThat(response.isActive()).isTrue();
+        
+        verify(categoryRepository, times(1)).findById(new CategoryId(parentId));
+        verify(categoryRepository, times(1)).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("3단계를 초과하는 카테고리는 생성할 수 없다")
+    void should_not_create_category_exceeding_max_level() {
+        // Given
+        String parentId = UUID.randomUUID().toString();
+        
+        Category thirdLevelCategory = Category.createChild(
+                new CategoryId(parentId),
+                new CategoryName("게이밍 노트북"),
+                new CategoryId(UUID.randomUUID().toString()),
+                3,
+                1
+        );
+        
+        request = CreateCategoryRequest.builder()
+                .name("ASUS 게이밍")
+                .parentId(parentId)
+                .sortOrder(1)
+                .build();
+        
+        when(categoryRepository.findById(new CategoryId(parentId)))
+                .thenReturn(Optional.of(thirdLevelCategory));
+
+        // When & Then
+        assertThatThrownBy(() -> createCategoryService.createCategory(request))
+                .isInstanceOf(InvalidCategoryLevelException.class)
+                .hasMessageContaining("Maximum category level is");
+        
+        verify(categoryRepository, times(1)).findById(new CategoryId(parentId));
+        verify(categoryRepository, never()).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 부모 카테고리로는 하위 카테고리를 생성할 수 없다")
+    void should_not_create_category_with_non_existent_parent() {
+        // Given
+        String parentId = UUID.randomUUID().toString();
+        
+        request = CreateCategoryRequest.builder()
+                .name("노트북")
+                .parentId(parentId)
+                .sortOrder(1)
+                .build();
+        
+        when(categoryRepository.findById(new CategoryId(parentId)))
+                .thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> createCategoryService.createCategory(request))
+                .isInstanceOf(ProductDomainException.class)
+                .hasMessageContaining("Parent category not found");
+        
+        verify(categoryRepository, times(1)).findById(new CategoryId(parentId));
+        verify(categoryRepository, never()).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("빈 이름으로 카테고리를 생성할 수 없다")
+    void should_not_create_category_with_empty_name() {
+        // Given
+        request = CreateCategoryRequest.builder()
+                .name("")
+                .parentId(null)
+                .sortOrder(1)
+                .build();
+
+        // When & Then
+        assertThatThrownBy(() -> createCategoryService.createCategory(request))
+                .isInstanceOf(InvalidCategoryNameException.class)
+                .hasMessageContaining("Category name cannot be");
+        
+        verify(categoryRepository, never()).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("null 이름으로 카테고리를 생성할 수 없다")
+    void should_not_create_category_with_null_name() {
+        // Given
+        request = CreateCategoryRequest.builder()
+                .name(null)
+                .parentId(null)
+                .sortOrder(1)
+                .build();
+
+        // When & Then
+        assertThatThrownBy(() -> createCategoryService.createCategory(request))
+                .isInstanceOf(InvalidCategoryNameException.class)
+                .hasMessageContaining("Category name cannot be");
+        
+        verify(categoryRepository, never()).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("너무 긴 이름으로 카테고리를 생성할 수 없다")
+    void should_not_create_category_with_too_long_name() {
+        // Given
+        String longName = "a".repeat(101);
+        request = CreateCategoryRequest.builder()
+                .name(longName)
+                .parentId(null)
+                .sortOrder(1)
+                .build();
+
+        // When & Then
+        assertThatThrownBy(() -> createCategoryService.createCategory(request))
+                .isInstanceOf(InvalidCategoryNameException.class)
+                .hasMessageContaining("Category name cannot exceed");
+        
+        verify(categoryRepository, never()).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("음수 정렬 순서로 카테고리를 생성할 수 없다")
+    void should_not_create_category_with_negative_sort_order() {
+        // Given
+        request = CreateCategoryRequest.builder()
+                .name("전자제품")
+                .parentId(null)
+                .sortOrder(-1)
+                .build();
+
+        // When & Then
+        assertThatThrownBy(() -> createCategoryService.createCategory(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Sort order must be positive");
+        
+        verify(categoryRepository, never()).save(any(Category.class));
+    }
+}

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -98,7 +98,7 @@ PRD 문서와 설계 문서를 기반으로 수립한 구현 작업 계획입니
 - [x] SearchProductsUseCase
 
 #### 5.3 Category UseCase
-- [ ] CreateCategoryUseCase
+- [x] CreateCategoryUseCase
 - [ ] UpdateCategoryUseCase
 - [ ] AssignProductToCategoryUseCase
 - [ ] GetCategoryTreeUseCase


### PR DESCRIPTION
## 작업 내용
docs/ 폴더의 설계문서를 참고하여 IMPLEMENTATION_PLAN.md에서 정리한 작업 중 5.3 Category UseCase의 CreateCategoryUseCase를 구현했습니다.

## 구현 사항
### TDD 방식 적용
- ✅ 테스트 코드를 먼저 작성한 후 구현 코드 작성
- ✅ 모든 테스트 통과 확인

### 구현된 기능
- ✅ CreateCategoryUseCase 인터페이스 정의
- ✅ CreateCategoryService 구현체 작성
- ✅ CreateCategoryRequest, CreateCategoryResponse DTO 구현
- ✅ 루트 카테고리 생성 기능
- ✅ 하위 카테고리 생성 기능
- ✅ 카테고리 레벨 제한(최대 3단계) 검증
- ✅ 입력값 검증 (이름 길이, 정렬 순서 등)

### 테스트 커버리지
- 루트 카테고리 생성 테스트
- 2단계, 3단계 하위 카테고리 생성 테스트
- 3단계 초과 카테고리 생성 방지 테스트
- 존재하지 않는 부모 카테고리 예외 테스트
- 빈 이름, null 이름, 긴 이름 검증 테스트
- 음수 정렬 순서 검증 테스트

## 테스트 결과
```
BUILD SUCCESSFUL
모든 테스트 통과
```

## SOLID 원칙 준수
- **단일 책임 원칙**: CreateCategoryService는 카테고리 생성만 담당
- **의존성 역전 원칙**: Repository 인터페이스에 의존

## Clean Code 원칙
- 의미 있는 메서드명 사용
- 20줄 이내의 작은 메서드
- 일관성 있는 코드 스타일

Closes #54

🤖 Generated with [Claude Code](https://claude.ai/code)