### PR TITLE
feat(#59): Category UseCase 구현 완료

### DIFF
--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/AssignProductToCategoryRequest.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/AssignProductToCategoryRequest.java
@@ -1,0 +1,25 @@
+package com.commerce.product.application.usecase;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AssignProductToCategoryRequest {
+    
+    @NotBlank(message = "Product ID is required")
+    private String productId;
+    
+    @NotNull(message = "Category IDs list is required")
+    @Size(max = 5, message = "Product can be assigned to maximum 5 categories")
+    private List<String> categoryIds;
+}

--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/AssignProductToCategoryResponse.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/AssignProductToCategoryResponse.java
@@ -1,0 +1,43 @@
+package com.commerce.product.application.usecase;
+
+import com.commerce.product.domain.model.CategoryId;
+import com.commerce.product.domain.model.Product;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AssignProductToCategoryResponse {
+    
+    private String productId;
+    private List<String> categoryIds;
+    private boolean success;
+    private String message;
+    
+    public static AssignProductToCategoryResponse success(Product product) {
+        return AssignProductToCategoryResponse.builder()
+                .productId(product.getId().value())
+                .categoryIds(product.getCategoryIds().stream()
+                        .map(CategoryId::value)
+                        .collect(Collectors.toList()))
+                .success(true)
+                .message("Product successfully assigned to categories")
+                .build();
+    }
+    
+    public static AssignProductToCategoryResponse failure(String productId, String message) {
+        return AssignProductToCategoryResponse.builder()
+                .productId(productId)
+                .categoryIds(List.of())
+                .success(false)
+                .message(message)
+                .build();
+    }
+}

--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/AssignProductToCategoryService.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/AssignProductToCategoryService.java
@@ -1,0 +1,64 @@
+package com.commerce.product.application.usecase;
+
+import com.commerce.product.domain.exception.InvalidCategoryIdException;
+import com.commerce.product.domain.exception.MaxCategoryLimitException;
+import com.commerce.product.domain.exception.ProductNotFoundException;
+import com.commerce.product.domain.model.Category;
+import com.commerce.product.domain.model.CategoryId;
+import com.commerce.product.domain.model.Product;
+import com.commerce.product.domain.model.ProductId;
+import com.commerce.product.domain.repository.CategoryRepository;
+import com.commerce.product.domain.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AssignProductToCategoryService implements AssignProductToCategoryUseCase {
+    
+    private final ProductRepository productRepository;
+    private final CategoryRepository categoryRepository;
+    
+    @Override
+    public AssignProductToCategoryResponse execute(AssignProductToCategoryRequest request) {
+        validateRequest(request);
+        
+        ProductId productId = ProductId.of(request.getProductId());
+        
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new ProductNotFoundException("Product not found: " + request.getProductId()));
+        
+        List<CategoryId> categoryIds = request.getCategoryIds().stream()
+                .map(CategoryId::of)
+                .collect(Collectors.toList());
+        
+        if (!categoryIds.isEmpty()) {
+            validateCategories(categoryIds);
+        }
+        
+        product.assignCategories(categoryIds);
+        
+        Product savedProduct = productRepository.save(product);
+        
+        return AssignProductToCategoryResponse.success(savedProduct);
+    }
+    
+    private void validateRequest(AssignProductToCategoryRequest request) {
+        if (request.getCategoryIds() != null && request.getCategoryIds().size() > 5) {
+            throw new MaxCategoryLimitException("상품은 최대 5개의 카테고리에만 할당할 수 있습니다");
+        }
+    }
+    
+    private void validateCategories(List<CategoryId> categoryIds) {
+        List<Category> categories = categoryRepository.findAllById(categoryIds);
+        
+        if (categories.size() != categoryIds.size()) {
+            throw new InvalidCategoryIdException("Some categories not found");
+        }
+    }
+}

--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/AssignProductToCategoryUseCase.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/AssignProductToCategoryUseCase.java
@@ -1,0 +1,6 @@
+package com.commerce.product.application.usecase;
+
+import com.commerce.common.application.usecase.UseCase;
+
+public interface AssignProductToCategoryUseCase extends UseCase<AssignProductToCategoryRequest, AssignProductToCategoryResponse> {
+}

--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/CategoryTreeNode.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/CategoryTreeNode.java
@@ -1,0 +1,50 @@
+package com.commerce.product.application.usecase;
+
+import com.commerce.product.domain.model.Category;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryTreeNode {
+    
+    private String id;
+    private String name;
+    private String parentId;
+    private int level;
+    private int sortOrder;
+    private boolean isActive;
+    private String fullPath;
+    
+    @Builder.Default
+    private List<CategoryTreeNode> children = new ArrayList<>();
+    
+    public static CategoryTreeNode from(Category category) {
+        return CategoryTreeNode.builder()
+                .id(category.getId().value())
+                .name(category.getName().value())
+                .parentId(category.getParentId() != null ? category.getParentId().value() : null)
+                .level(category.getLevel())
+                .sortOrder(category.getSortOrder())
+                .isActive(category.isActive())
+                .fullPath(category.getFullPath())
+                .children(new ArrayList<>())
+                .build();
+    }
+    
+    public void addChild(CategoryTreeNode child) {
+        this.children.add(child);
+    }
+    
+    public void sortChildren() {
+        children.sort((a, b) -> Integer.compare(a.getSortOrder(), b.getSortOrder()));
+        children.forEach(CategoryTreeNode::sortChildren);
+    }
+}

--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/CreateCategoryRequest.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/CreateCategoryRequest.java
@@ -1,0 +1,26 @@
+package com.commerce.product.application.usecase;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateCategoryRequest {
+    
+    @NotBlank(message = "Category name is required")
+    @Size(min = 1, max = 100, message = "Category name must be between 1 and 100 characters")
+    private String name;
+    
+    private String parentId;
+    
+    @Min(value = 0, message = "Sort order must be non-negative")
+    private int sortOrder;
+}

--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/CreateCategoryResponse.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/CreateCategoryResponse.java
@@ -1,0 +1,34 @@
+package com.commerce.product.application.usecase;
+
+import com.commerce.product.domain.model.Category;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateCategoryResponse {
+    
+    private String categoryId;
+    private String name;
+    private String parentId;
+    private int level;
+    private int sortOrder;
+    private boolean isActive;
+    private String fullPath;
+    
+    public static CreateCategoryResponse from(Category category) {
+        return CreateCategoryResponse.builder()
+                .categoryId(category.getId().value())
+                .name(category.getName().value())
+                .parentId(category.getParentId() != null ? category.getParentId().value() : null)
+                .level(category.getLevel())
+                .sortOrder(category.getSortOrder())
+                .isActive(category.isActive())
+                .fullPath(category.getFullPath())
+                .build();
+    }
+}

--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/CreateCategoryService.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/CreateCategoryService.java
@@ -1,0 +1,84 @@
+package com.commerce.product.application.usecase;
+
+import com.commerce.product.domain.exception.InvalidCategoryIdException;
+import com.commerce.product.domain.exception.InvalidCategoryNameException;
+import com.commerce.product.domain.exception.MaxCategoryDepthException;
+import com.commerce.product.domain.model.Category;
+import com.commerce.product.domain.model.CategoryId;
+import com.commerce.product.domain.model.CategoryName;
+import com.commerce.product.domain.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CreateCategoryService implements CreateCategoryUseCase {
+    
+    private final CategoryRepository categoryRepository;
+    
+    @Override
+    public CreateCategoryResponse execute(CreateCategoryRequest request) {
+        validateRequest(request);
+        
+        Category category;
+        
+        if (request.getParentId() == null) {
+            category = createRootCategory(request);
+        } else {
+            category = createChildCategory(request);
+        }
+        
+        Category savedCategory = categoryRepository.save(category);
+        
+        return CreateCategoryResponse.from(savedCategory);
+    }
+    
+    private void validateRequest(CreateCategoryRequest request) {
+        if (request.getName() == null || request.getName().trim().isEmpty()) {
+            throw new InvalidCategoryNameException("Category name cannot be null or empty");
+        }
+        
+        if (request.getName().length() > 100) {
+            throw new InvalidCategoryNameException("Category name must not exceed 100 characters");
+        }
+        
+        if (request.getSortOrder() < 0) {
+            throw new IllegalArgumentException("Sort order must be non-negative");
+        }
+    }
+    
+    private Category createRootCategory(CreateCategoryRequest request) {
+        return Category.createRoot(
+                CategoryId.generate(),
+                CategoryName.of(request.getName()),
+                request.getSortOrder()
+        );
+    }
+    
+    private Category createChildCategory(CreateCategoryRequest request) {
+        CategoryId parentId = CategoryId.of(request.getParentId());
+        
+        Category parentCategory = categoryRepository.findById(parentId)
+                .orElseThrow(() -> new InvalidCategoryIdException("Parent category not found: " + request.getParentId()));
+        
+        if (parentCategory.getLevel() >= 3) {
+            throw new MaxCategoryDepthException("Maximum category depth is 3. Cannot add child to level " + parentCategory.getLevel() + " category");
+        }
+        
+        int childLevel = parentCategory.getLevel() + 1;
+        
+        Category childCategory = Category.createChild(
+                CategoryId.generate(),
+                CategoryName.of(request.getName()),
+                parentId,
+                childLevel,
+                request.getSortOrder()
+        );
+        
+        parentCategory.addChild(childCategory);
+        
+        return childCategory;
+    }
+}

--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/CreateCategoryUseCase.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/CreateCategoryUseCase.java
@@ -1,0 +1,6 @@
+package com.commerce.product.application.usecase;
+
+import com.commerce.common.application.usecase.UseCase;
+
+public interface CreateCategoryUseCase extends UseCase<CreateCategoryRequest, CreateCategoryResponse> {
+}

--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/GetCategoryTreeRequest.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/GetCategoryTreeRequest.java
@@ -1,0 +1,16 @@
+package com.commerce.product.application.usecase;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetCategoryTreeRequest {
+    
+    @Builder.Default
+    private boolean includeInactive = false;
+}

--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/GetCategoryTreeResponse.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/GetCategoryTreeResponse.java
@@ -1,0 +1,33 @@
+package com.commerce.product.application.usecase;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetCategoryTreeResponse {
+    
+    private List<CategoryTreeNode> categories;
+    private int totalCount;
+    
+    public static GetCategoryTreeResponse of(List<CategoryTreeNode> categories) {
+        return GetCategoryTreeResponse.builder()
+                .categories(categories)
+                .totalCount(countAllNodes(categories))
+                .build();
+    }
+    
+    private static int countAllNodes(List<CategoryTreeNode> nodes) {
+        int count = nodes.size();
+        for (CategoryTreeNode node : nodes) {
+            count += countAllNodes(node.getChildren());
+        }
+        return count;
+    }
+}

--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/GetCategoryTreeService.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/GetCategoryTreeService.java
@@ -1,0 +1,75 @@
+package com.commerce.product.application.usecase;
+
+import com.commerce.product.domain.model.Category;
+import com.commerce.product.domain.model.CategoryId;
+import com.commerce.product.domain.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetCategoryTreeService implements GetCategoryTreeUseCase {
+    
+    private final CategoryRepository categoryRepository;
+    
+    @Override
+    public GetCategoryTreeResponse execute(GetCategoryTreeRequest request) {
+        List<Category> rootCategories = categoryRepository.findRootCategories();
+        
+        List<CategoryTreeNode> treeNodes = rootCategories.stream()
+                .filter(category -> request.isIncludeInactive() || category.isActive())
+                .map(this::buildCategoryTree)
+                .sorted(Comparator.comparingInt(CategoryTreeNode::getSortOrder))
+                .collect(Collectors.toList());
+        
+        if (!request.isIncludeInactive()) {
+            treeNodes = filterInactiveNodes(treeNodes);
+        }
+        
+        return GetCategoryTreeResponse.of(treeNodes);
+    }
+    
+    private CategoryTreeNode buildCategoryTree(Category category) {
+        CategoryTreeNode node = CategoryTreeNode.from(category);
+        
+        List<Category> children = categoryRepository.findByParentId(category.getId());
+        
+        for (Category child : children) {
+            CategoryTreeNode childNode = buildCategoryTree(child);
+            node.addChild(childNode);
+        }
+        
+        node.sortChildren();
+        
+        return node;
+    }
+    
+    private List<CategoryTreeNode> filterInactiveNodes(List<CategoryTreeNode> nodes) {
+        List<CategoryTreeNode> filtered = new ArrayList<>();
+        
+        for (CategoryTreeNode node : nodes) {
+            if (node.isActive()) {
+                CategoryTreeNode filteredNode = CategoryTreeNode.builder()
+                        .id(node.getId())
+                        .name(node.getName())
+                        .parentId(node.getParentId())
+                        .level(node.getLevel())
+                        .sortOrder(node.getSortOrder())
+                        .isActive(node.isActive())
+                        .fullPath(node.getFullPath())
+                        .children(filterInactiveNodes(node.getChildren()))
+                        .build();
+                filtered.add(filteredNode);
+            }
+        }
+        
+        return filtered;
+    }
+}

--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/GetCategoryTreeUseCase.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/GetCategoryTreeUseCase.java
@@ -1,0 +1,6 @@
+package com.commerce.product.application.usecase;
+
+import com.commerce.common.application.usecase.UseCase;
+
+public interface GetCategoryTreeUseCase extends UseCase<GetCategoryTreeRequest, GetCategoryTreeResponse> {
+}

--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/UpdateCategoryRequest.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/UpdateCategoryRequest.java
@@ -1,0 +1,28 @@
+package com.commerce.product.application.usecase;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateCategoryRequest {
+    
+    @NotBlank(message = "Category ID is required")
+    private String categoryId;
+    
+    @Size(min = 1, max = 100, message = "Category name must be between 1 and 100 characters")
+    private String name;
+    
+    @Min(value = 0, message = "Sort order must be non-negative")
+    private Integer sortOrder;
+    
+    private Boolean isActive;
+}

--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/UpdateCategoryResponse.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/UpdateCategoryResponse.java
@@ -1,0 +1,34 @@
+package com.commerce.product.application.usecase;
+
+import com.commerce.product.domain.model.Category;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateCategoryResponse {
+    
+    private String categoryId;
+    private String name;
+    private String parentId;
+    private int level;
+    private int sortOrder;
+    private boolean isActive;
+    private String fullPath;
+    
+    public static UpdateCategoryResponse from(Category category) {
+        return UpdateCategoryResponse.builder()
+                .categoryId(category.getId().value())
+                .name(category.getName().value())
+                .parentId(category.getParentId() != null ? category.getParentId().value() : null)
+                .level(category.getLevel())
+                .sortOrder(category.getSortOrder())
+                .isActive(category.isActive())
+                .fullPath(category.getFullPath())
+                .build();
+    }
+}

--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/UpdateCategoryService.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/UpdateCategoryService.java
@@ -1,0 +1,70 @@
+package com.commerce.product.application.usecase;
+
+import com.commerce.product.domain.exception.CannotDeactivateCategoryException;
+import com.commerce.product.domain.exception.InvalidCategoryIdException;
+import com.commerce.product.domain.exception.InvalidCategoryNameException;
+import com.commerce.product.domain.model.Category;
+import com.commerce.product.domain.model.CategoryId;
+import com.commerce.product.domain.model.CategoryName;
+import com.commerce.product.domain.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UpdateCategoryService implements UpdateCategoryUseCase {
+    
+    private final CategoryRepository categoryRepository;
+    
+    @Override
+    public UpdateCategoryResponse execute(UpdateCategoryRequest request) {
+        CategoryId categoryId = CategoryId.of(request.getCategoryId());
+        
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new InvalidCategoryIdException("Category not found: " + request.getCategoryId()));
+        
+        if (request.getName() != null) {
+            validateName(request.getName());
+            category.updateName(CategoryName.of(request.getName()));
+        }
+        
+        if (request.getSortOrder() != null) {
+            validateSortOrder(request.getSortOrder());
+            category.updateSortOrder(request.getSortOrder());
+        }
+        
+        if (request.getIsActive() != null) {
+            if (request.getIsActive()) {
+                category.activate();
+            } else {
+                boolean hasActiveProducts = categoryRepository.hasActiveProducts(categoryId);
+                if (hasActiveProducts) {
+                    throw new CannotDeactivateCategoryException("Cannot deactivate category with active products");
+                }
+                category.deactivate();
+            }
+        }
+        
+        Category savedCategory = categoryRepository.save(category);
+        
+        return UpdateCategoryResponse.from(savedCategory);
+    }
+    
+    private void validateName(String name) {
+        if (name == null || name.trim().isEmpty()) {
+            throw new InvalidCategoryNameException("Category name cannot be null or empty");
+        }
+        
+        if (name.length() > 100) {
+            throw new InvalidCategoryNameException("Category name must not exceed 100 characters");
+        }
+    }
+    
+    private void validateSortOrder(Integer sortOrder) {
+        if (sortOrder < 0) {
+            throw new IllegalArgumentException("Sort order must be non-negative");
+        }
+    }
+}

--- a/core/product-core/src/main/java/com/commerce/product/application/usecase/UpdateCategoryUseCase.java
+++ b/core/product-core/src/main/java/com/commerce/product/application/usecase/UpdateCategoryUseCase.java
@@ -1,0 +1,6 @@
+package com.commerce.product.application.usecase;
+
+import com.commerce.common.application.usecase.UseCase;
+
+public interface UpdateCategoryUseCase extends UseCase<UpdateCategoryRequest, UpdateCategoryResponse> {
+}

--- a/core/product-core/src/main/java/com/commerce/product/domain/model/CategoryName.java
+++ b/core/product-core/src/main/java/com/commerce/product/domain/model/CategoryName.java
@@ -4,10 +4,14 @@ import com.commerce.common.domain.model.ValueObject;
 import com.commerce.product.domain.exception.InvalidCategoryNameException;
 
 public record CategoryName(String value) implements ValueObject {
-    private static final int MAX_LENGTH = 50;
+    private static final int MAX_LENGTH = 100;
     
     public CategoryName {
         validate(value);
+    }
+    
+    public static CategoryName of(String value) {
+        return new CategoryName(value);
     }
 
     private static void validate(String value) {

--- a/core/product-core/src/test/java/com/commerce/product/application/usecase/AssignProductToCategoryUseCaseTest.java
+++ b/core/product-core/src/test/java/com/commerce/product/application/usecase/AssignProductToCategoryUseCaseTest.java
@@ -1,0 +1,344 @@
+package com.commerce.product.application.usecase;
+
+import com.commerce.product.domain.exception.InvalidCategoryIdException;
+import com.commerce.product.domain.exception.MaxCategoryLimitException;
+import com.commerce.product.domain.exception.ProductNotFoundException;
+import com.commerce.product.domain.model.*;
+import com.commerce.product.domain.model.ProductStatus;
+import com.commerce.product.domain.repository.CategoryRepository;
+import com.commerce.product.domain.repository.ProductRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AssignProductToCategoryUseCaseTest {
+
+    @Mock
+    private ProductRepository productRepository;
+    
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    private AssignProductToCategoryUseCase assignProductToCategoryUseCase;
+
+    @BeforeEach
+    void setUp() {
+        assignProductToCategoryUseCase = new AssignProductToCategoryService(productRepository, categoryRepository);
+    }
+
+    @Test
+    @DisplayName("상품을 단일 카테고리에 할당할 수 있다")
+    void shouldAssignProductToSingleCategory() {
+        // Given
+        String productId = UUID.randomUUID().toString();
+        String categoryId = UUID.randomUUID().toString();
+        
+        Product product = Product.restore(
+                ProductId.of(productId),
+                ProductName.of("노트북"),
+                "고성능 노트북",
+                ProductType.NORMAL,
+                ProductStatus.ACTIVE,
+                List.of(),
+                List.of(),
+                false,
+                0L
+        );
+        
+        Category category = Category.createRoot(
+                CategoryId.of(categoryId),
+                CategoryName.of("전자제품"),
+                1
+        );
+
+        AssignProductToCategoryRequest request = AssignProductToCategoryRequest.builder()
+                .productId(productId)
+                .categoryIds(List.of(categoryId))
+                .build();
+
+        when(productRepository.findById(ProductId.of(productId)))
+                .thenReturn(Optional.of(product));
+        when(categoryRepository.findAllById(any()))
+                .thenReturn(List.of(category));
+        when(productRepository.save(any(Product.class))).thenReturn(product);
+
+        // When
+        AssignProductToCategoryResponse response = assignProductToCategoryUseCase.execute(request);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getProductId()).isEqualTo(productId);
+        assertThat(response.getCategoryIds()).containsExactly(categoryId);
+        assertThat(response.isSuccess()).isTrue();
+
+        verify(productRepository, times(1)).findById(ProductId.of(productId));
+        verify(categoryRepository, times(1)).findAllById(any());
+        verify(productRepository, times(1)).save(any(Product.class));
+    }
+
+    @Test
+    @DisplayName("상품을 여러 카테고리에 할당할 수 있다")
+    void shouldAssignProductToMultipleCategories() {
+        // Given
+        String productId = UUID.randomUUID().toString();
+        String categoryId1 = UUID.randomUUID().toString();
+        String categoryId2 = UUID.randomUUID().toString();
+        String categoryId3 = UUID.randomUUID().toString();
+        
+        Product product = Product.restore(
+                ProductId.of(productId),
+                ProductName.of("스마트워치"),
+                "피트니스 기능이 있는 스마트워치",
+                ProductType.NORMAL,
+                ProductStatus.ACTIVE,
+                List.of(),
+                List.of(),
+                false,
+                0L
+        );
+        
+        Category category1 = Category.createRoot(
+                CategoryId.of(categoryId1),
+                CategoryName.of("전자제품"),
+                1
+        );
+        
+        Category category2 = Category.createRoot(
+                CategoryId.of(categoryId2),
+                CategoryName.of("웨어러블"),
+                2
+        );
+        
+        Category category3 = Category.createRoot(
+                CategoryId.of(categoryId3),
+                CategoryName.of("피트니스"),
+                3
+        );
+
+        AssignProductToCategoryRequest request = AssignProductToCategoryRequest.builder()
+                .productId(productId)
+                .categoryIds(List.of(categoryId1, categoryId2, categoryId3))
+                .build();
+
+        when(productRepository.findById(ProductId.of(productId)))
+                .thenReturn(Optional.of(product));
+        when(categoryRepository.findAllById(any()))
+                .thenReturn(List.of(category1, category2, category3));
+        when(productRepository.save(any(Product.class))).thenReturn(product);
+
+        // When
+        AssignProductToCategoryResponse response = assignProductToCategoryUseCase.execute(request);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getProductId()).isEqualTo(productId);
+        assertThat(response.getCategoryIds()).containsExactlyInAnyOrder(categoryId1, categoryId2, categoryId3);
+        assertThat(response.isSuccess()).isTrue();
+
+        verify(productRepository, times(1)).save(any(Product.class));
+    }
+
+    @Test
+    @DisplayName("상품은 최대 5개의 카테고리에만 할당할 수 있다")
+    void shouldNotAssignProductToMoreThanFiveCategories() {
+        // Given
+        String productId = UUID.randomUUID().toString();
+        List<String> categoryIds = Arrays.asList(
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString() // 6개
+        );
+
+        AssignProductToCategoryRequest request = AssignProductToCategoryRequest.builder()
+                .productId(productId)
+                .categoryIds(categoryIds)
+                .build();
+
+        // When & Then
+        assertThatThrownBy(() -> assignProductToCategoryUseCase.execute(request))
+                .isInstanceOf(MaxCategoryLimitException.class)
+                .hasMessageContaining("최대 5개의 카테고리");
+
+        verify(productRepository, never()).findById(any(ProductId.class));
+        verify(productRepository, never()).save(any(Product.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 상품에는 카테고리를 할당할 수 없다")
+    void shouldNotAssignCategoryToNonExistentProduct() {
+        // Given
+        String productId = UUID.randomUUID().toString();
+        String categoryId = UUID.randomUUID().toString();
+
+        AssignProductToCategoryRequest request = AssignProductToCategoryRequest.builder()
+                .productId(productId)
+                .categoryIds(List.of(categoryId))
+                .build();
+
+        when(productRepository.findById(ProductId.of(productId)))
+                .thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> assignProductToCategoryUseCase.execute(request))
+                .isInstanceOf(ProductNotFoundException.class)
+                .hasMessageContaining("Product not found");
+
+        verify(productRepository, times(1)).findById(ProductId.of(productId));
+        verify(categoryRepository, never()).findAllById(any());
+        verify(productRepository, never()).save(any(Product.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 카테고리는 상품에 할당할 수 없다")
+    void shouldNotAssignNonExistentCategoryToProduct() {
+        // Given
+        String productId = UUID.randomUUID().toString();
+        String existingCategoryId = UUID.randomUUID().toString();
+        String nonExistentCategoryId = UUID.randomUUID().toString();
+        
+        Product product = Product.restore(
+                ProductId.of(productId),
+                ProductName.of("노트북"),
+                "고성능 노트북",
+                ProductType.NORMAL,
+                ProductStatus.ACTIVE,
+                List.of(),
+                List.of(),
+                false,
+                0L
+        );
+        
+        Category existingCategory = Category.createRoot(
+                CategoryId.of(existingCategoryId),
+                CategoryName.of("전자제품"),
+                1
+        );
+
+        AssignProductToCategoryRequest request = AssignProductToCategoryRequest.builder()
+                .productId(productId)
+                .categoryIds(List.of(existingCategoryId, nonExistentCategoryId))
+                .build();
+
+        when(productRepository.findById(ProductId.of(productId)))
+                .thenReturn(Optional.of(product));
+        when(categoryRepository.findAllById(any()))
+                .thenReturn(List.of(existingCategory)); // 하나만 반환
+
+        // When & Then
+        assertThatThrownBy(() -> assignProductToCategoryUseCase.execute(request))
+                .isInstanceOf(InvalidCategoryIdException.class)
+                .hasMessageContaining("Some categories not found");
+
+        verify(productRepository, times(1)).findById(ProductId.of(productId));
+        verify(categoryRepository, times(1)).findAllById(any());
+        verify(productRepository, never()).save(any(Product.class));
+    }
+
+    @Test
+    @DisplayName("빈 카테고리 목록으로 상품의 카테고리를 모두 제거할 수 있다")
+    void shouldRemoveAllCategoriesWhenEmptyListProvided() {
+        // Given
+        String productId = UUID.randomUUID().toString();
+        
+        Product product = Product.restore(
+                ProductId.of(productId),
+                ProductName.of("노트북"),
+                "고성능 노트북",
+                ProductType.NORMAL,
+                ProductStatus.ACTIVE,
+                List.of(),
+                List.of(),
+                false,
+                0L
+        );
+        
+        // 기존에 카테고리가 할당되어 있다고 가정
+        product.assignCategories(List.of(CategoryId.of(UUID.randomUUID().toString())));
+
+        AssignProductToCategoryRequest request = AssignProductToCategoryRequest.builder()
+                .productId(productId)
+                .categoryIds(List.of())
+                .build();
+
+        when(productRepository.findById(ProductId.of(productId)))
+                .thenReturn(Optional.of(product));
+        when(productRepository.save(any(Product.class))).thenReturn(product);
+
+        // When
+        AssignProductToCategoryResponse response = assignProductToCategoryUseCase.execute(request);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getProductId()).isEqualTo(productId);
+        assertThat(response.getCategoryIds()).isEmpty();
+        assertThat(response.isSuccess()).isTrue();
+
+        verify(productRepository, times(1)).save(any(Product.class));
+    }
+
+    @Test
+    @DisplayName("비활성 카테고리도 상품에 할당할 수 있다")
+    void shouldAssignInactiveCategoryToProduct() {
+        // Given
+        String productId = UUID.randomUUID().toString();
+        String categoryId = UUID.randomUUID().toString();
+        
+        Product product = Product.restore(
+                ProductId.of(productId),
+                ProductName.of("노트북"),
+                "고성능 노트북",
+                ProductType.NORMAL,
+                ProductStatus.ACTIVE,
+                List.of(),
+                List.of(),
+                false,
+                0L
+        );
+        
+        Category category = Category.createRoot(
+                CategoryId.of(categoryId),
+                CategoryName.of("전자제품"),
+                1
+        );
+        category.deactivate(); // 카테고리 비활성화
+
+        AssignProductToCategoryRequest request = AssignProductToCategoryRequest.builder()
+                .productId(productId)
+                .categoryIds(List.of(categoryId))
+                .build();
+
+        when(productRepository.findById(ProductId.of(productId)))
+                .thenReturn(Optional.of(product));
+        when(categoryRepository.findAllById(any()))
+                .thenReturn(List.of(category));
+        when(productRepository.save(any(Product.class))).thenReturn(product);
+
+        // When
+        AssignProductToCategoryResponse response = assignProductToCategoryUseCase.execute(request);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getCategoryIds()).containsExactly(categoryId);
+        assertThat(response.isSuccess()).isTrue();
+
+        verify(productRepository, times(1)).save(any(Product.class));
+    }
+}

--- a/core/product-core/src/test/java/com/commerce/product/application/usecase/CreateCategoryUseCaseTest.java
+++ b/core/product-core/src/test/java/com/commerce/product/application/usecase/CreateCategoryUseCaseTest.java
@@ -1,0 +1,299 @@
+package com.commerce.product.application.usecase;
+
+import com.commerce.product.domain.exception.InvalidCategoryIdException;
+import com.commerce.product.domain.exception.InvalidCategoryNameException;
+import com.commerce.product.domain.exception.MaxCategoryDepthException;
+import com.commerce.product.domain.model.Category;
+import com.commerce.product.domain.model.CategoryId;
+import com.commerce.product.domain.model.CategoryName;
+import com.commerce.product.domain.repository.CategoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CreateCategoryUseCaseTest {
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    private CreateCategoryUseCase createCategoryUseCase;
+
+    @BeforeEach
+    void setUp() {
+        createCategoryUseCase = new CreateCategoryService(categoryRepository);
+    }
+
+    @Test
+    @DisplayName("루트 카테고리를 생성할 수 있다")
+    void shouldCreateRootCategory() {
+        // Given
+        String categoryName = "전자제품";
+        int sortOrder = 1;
+        CreateCategoryRequest request = CreateCategoryRequest.builder()
+                .name(categoryName)
+                .parentId(null)
+                .sortOrder(sortOrder)
+                .build();
+
+        Category savedCategory = Category.createRoot(
+                CategoryId.generate(),
+                CategoryName.of(categoryName),
+                sortOrder
+        );
+
+        when(categoryRepository.save(any(Category.class))).thenReturn(savedCategory);
+
+        // When
+        CreateCategoryResponse response = createCategoryUseCase.execute(request);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getCategoryId()).isNotNull();
+        assertThat(response.getName()).isEqualTo(categoryName);
+        assertThat(response.getLevel()).isEqualTo(1);
+        assertThat(response.getParentId()).isNull();
+        assertThat(response.getSortOrder()).isEqualTo(sortOrder);
+        assertThat(response.isActive()).isTrue();
+
+        verify(categoryRepository, times(1)).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("하위 카테고리를 생성할 수 있다")
+    void shouldCreateChildCategory() {
+        // Given
+        String parentId = UUID.randomUUID().toString();
+        String categoryName = "노트북";
+        int sortOrder = 1;
+        
+        Category parentCategory = Category.createRoot(
+                CategoryId.of(parentId),
+                CategoryName.of("전자제품"),
+                1
+        );
+
+        CreateCategoryRequest request = CreateCategoryRequest.builder()
+                .name(categoryName)
+                .parentId(parentId)
+                .sortOrder(sortOrder)
+                .build();
+
+        when(categoryRepository.findById(CategoryId.of(parentId)))
+                .thenReturn(Optional.of(parentCategory));
+
+        Category savedCategory = Category.createChild(
+                CategoryId.generate(),
+                CategoryName.of(categoryName),
+                CategoryId.of(parentId),
+                2,
+                sortOrder
+        );
+
+        when(categoryRepository.save(any(Category.class))).thenReturn(savedCategory);
+
+        // When
+        CreateCategoryResponse response = createCategoryUseCase.execute(request);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getCategoryId()).isNotNull();
+        assertThat(response.getName()).isEqualTo(categoryName);
+        assertThat(response.getLevel()).isEqualTo(2);
+        assertThat(response.getParentId()).isEqualTo(parentId);
+        assertThat(response.getSortOrder()).isEqualTo(sortOrder);
+        assertThat(response.isActive()).isTrue();
+
+        verify(categoryRepository, times(1)).findById(CategoryId.of(parentId));
+        verify(categoryRepository, times(1)).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("3단계 하위 카테고리를 생성할 수 있다")
+    void shouldCreateThirdLevelCategory() {
+        // Given
+        String rootId = UUID.randomUUID().toString();
+        String parentId = UUID.randomUUID().toString();
+        String categoryName = "게이밍 노트북";
+        int sortOrder = 1;
+        
+        Category rootCategory = Category.createRoot(
+                CategoryId.of(rootId),
+                CategoryName.of("전자제품"),
+                1
+        );
+        
+        Category parentCategory = Category.createChild(
+                CategoryId.of(parentId),
+                CategoryName.of("노트북"),
+                CategoryId.of(rootId),
+                2,
+                1
+        );
+
+        CreateCategoryRequest request = CreateCategoryRequest.builder()
+                .name(categoryName)
+                .parentId(parentId)
+                .sortOrder(sortOrder)
+                .build();
+
+        when(categoryRepository.findById(CategoryId.of(parentId)))
+                .thenReturn(Optional.of(parentCategory));
+
+        Category savedCategory = Category.createChild(
+                CategoryId.generate(),
+                CategoryName.of(categoryName),
+                CategoryId.of(parentId),
+                3,
+                sortOrder
+        );
+
+        when(categoryRepository.save(any(Category.class))).thenReturn(savedCategory);
+
+        // When
+        CreateCategoryResponse response = createCategoryUseCase.execute(request);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getLevel()).isEqualTo(3);
+        assertThat(response.getParentId()).isEqualTo(parentId);
+    }
+
+    @Test
+    @DisplayName("3단계 카테고리에는 하위 카테고리를 생성할 수 없다")
+    void shouldNotCreateChildForThirdLevelCategory() {
+        // Given
+        String parentId = UUID.randomUUID().toString();
+        
+        Category thirdLevelCategory = Category.createChild(
+                CategoryId.of(parentId),
+                CategoryName.of("게이밍 노트북"),
+                CategoryId.of(UUID.randomUUID().toString()),
+                3,
+                1
+        );
+
+        CreateCategoryRequest request = CreateCategoryRequest.builder()
+                .name("하위 카테고리")
+                .parentId(parentId)
+                .sortOrder(1)
+                .build();
+
+        when(categoryRepository.findById(CategoryId.of(parentId)))
+                .thenReturn(Optional.of(thirdLevelCategory));
+
+        // When & Then
+        assertThatThrownBy(() -> createCategoryUseCase.execute(request))
+                .isInstanceOf(MaxCategoryDepthException.class)
+                .hasMessageContaining("Maximum category depth");
+
+        verify(categoryRepository, times(1)).findById(CategoryId.of(parentId));
+        verify(categoryRepository, never()).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 부모 카테고리로 하위 카테고리를 생성할 수 없다")
+    void shouldNotCreateChildWithNonExistentParent() {
+        // Given
+        String parentId = UUID.randomUUID().toString();
+
+        CreateCategoryRequest request = CreateCategoryRequest.builder()
+                .name("노트북")
+                .parentId(parentId)
+                .sortOrder(1)
+                .build();
+
+        when(categoryRepository.findById(CategoryId.of(parentId)))
+                .thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> createCategoryUseCase.execute(request))
+                .isInstanceOf(InvalidCategoryIdException.class)
+                .hasMessageContaining("Parent category not found");
+
+        verify(categoryRepository, times(1)).findById(CategoryId.of(parentId));
+        verify(categoryRepository, never()).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("빈 이름으로 카테고리를 생성할 수 없다")
+    void shouldNotCreateCategoryWithEmptyName() {
+        // Given
+        CreateCategoryRequest request = CreateCategoryRequest.builder()
+                .name("")
+                .parentId(null)
+                .sortOrder(1)
+                .build();
+
+        // When & Then
+        assertThatThrownBy(() -> createCategoryUseCase.execute(request))
+                .isInstanceOf(InvalidCategoryNameException.class);
+
+        verify(categoryRepository, never()).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("null 이름으로 카테고리를 생성할 수 없다")
+    void shouldNotCreateCategoryWithNullName() {
+        // Given
+        CreateCategoryRequest request = CreateCategoryRequest.builder()
+                .name(null)
+                .parentId(null)
+                .sortOrder(1)
+                .build();
+
+        // When & Then
+        assertThatThrownBy(() -> createCategoryUseCase.execute(request))
+                .isInstanceOf(InvalidCategoryNameException.class);
+
+        verify(categoryRepository, never()).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("너무 긴 이름으로 카테고리를 생성할 수 없다")
+    void shouldNotCreateCategoryWithTooLongName() {
+        // Given
+        String longName = "a".repeat(101); // 100자 초과
+        CreateCategoryRequest request = CreateCategoryRequest.builder()
+                .name(longName)
+                .parentId(null)
+                .sortOrder(1)
+                .build();
+
+        // When & Then
+        assertThatThrownBy(() -> createCategoryUseCase.execute(request))
+                .isInstanceOf(InvalidCategoryNameException.class)
+                .hasMessageContaining("100 characters");
+
+        verify(categoryRepository, never()).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("음수 정렬 순서로 카테고리를 생성할 수 없다")
+    void shouldNotCreateCategoryWithNegativeSortOrder() {
+        // Given
+        CreateCategoryRequest request = CreateCategoryRequest.builder()
+                .name("전자제품")
+                .parentId(null)
+                .sortOrder(-1)
+                .build();
+
+        // When & Then
+        assertThatThrownBy(() -> createCategoryUseCase.execute(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Sort order must be non-negative");
+
+        verify(categoryRepository, never()).save(any(Category.class));
+    }
+}

--- a/core/product-core/src/test/java/com/commerce/product/application/usecase/GetCategoryTreeUseCaseTest.java
+++ b/core/product-core/src/test/java/com/commerce/product/application/usecase/GetCategoryTreeUseCaseTest.java
@@ -1,0 +1,316 @@
+package com.commerce.product.application.usecase;
+
+import com.commerce.product.domain.model.Category;
+import com.commerce.product.domain.model.CategoryId;
+import com.commerce.product.domain.model.CategoryName;
+import com.commerce.product.domain.repository.CategoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GetCategoryTreeUseCaseTest {
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    private GetCategoryTreeUseCase getCategoryTreeUseCase;
+
+    @BeforeEach
+    void setUp() {
+        getCategoryTreeUseCase = new GetCategoryTreeService(categoryRepository);
+    }
+
+    @Test
+    @DisplayName("전체 카테고리 트리를 조회할 수 있다")
+    void shouldGetFullCategoryTree() {
+        // Given
+        String rootId1 = UUID.randomUUID().toString();
+        String rootId2 = UUID.randomUUID().toString();
+        String childId1 = UUID.randomUUID().toString();
+        String childId2 = UUID.randomUUID().toString();
+        String grandChildId = UUID.randomUUID().toString();
+
+        Category root1 = Category.createRoot(
+                CategoryId.of(rootId1),
+                CategoryName.of("전자제품"),
+                1
+        );
+
+        Category root2 = Category.createRoot(
+                CategoryId.of(rootId2),
+                CategoryName.of("의류"),
+                2
+        );
+
+        Category child1 = Category.createChild(
+                CategoryId.of(childId1),
+                CategoryName.of("노트북"),
+                CategoryId.of(rootId1),
+                2,
+                1
+        );
+
+        Category child2 = Category.createChild(
+                CategoryId.of(childId2),
+                CategoryName.of("스마트폰"),
+                CategoryId.of(rootId1),
+                2,
+                2
+        );
+
+        Category grandChild = Category.createChild(
+                CategoryId.of(grandChildId),
+                CategoryName.of("게이밍 노트북"),
+                CategoryId.of(childId1),
+                3,
+                1
+        );
+
+        GetCategoryTreeRequest request = GetCategoryTreeRequest.builder()
+                .includeInactive(false)
+                .build();
+
+        when(categoryRepository.findRootCategories()).thenReturn(Arrays.asList(root1, root2));
+        when(categoryRepository.findByParentId(CategoryId.of(rootId1)))
+                .thenReturn(Arrays.asList(child1, child2));
+        when(categoryRepository.findByParentId(CategoryId.of(rootId2)))
+                .thenReturn(List.of());
+        when(categoryRepository.findByParentId(CategoryId.of(childId1)))
+                .thenReturn(List.of(grandChild));
+        when(categoryRepository.findByParentId(CategoryId.of(childId2)))
+                .thenReturn(List.of());
+        when(categoryRepository.findByParentId(CategoryId.of(grandChildId)))
+                .thenReturn(List.of());
+
+        // When
+        GetCategoryTreeResponse response = getCategoryTreeUseCase.execute(request);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getCategories()).hasSize(2);
+        
+        CategoryTreeNode electronics = response.getCategories().get(0);
+        assertThat(electronics.getName()).isEqualTo("전자제품");
+        assertThat(electronics.getChildren()).hasSize(2);
+        
+        CategoryTreeNode laptop = electronics.getChildren().get(0);
+        assertThat(laptop.getName()).isEqualTo("노트북");
+        assertThat(laptop.getLevel()).isEqualTo(2);
+        assertThat(laptop.getChildren()).hasSize(1);
+        
+        CategoryTreeNode gamingLaptop = laptop.getChildren().get(0);
+        assertThat(gamingLaptop.getName()).isEqualTo("게이밍 노트북");
+        assertThat(gamingLaptop.getLevel()).isEqualTo(3);
+        assertThat(gamingLaptop.getChildren()).isEmpty();
+
+        verify(categoryRepository, times(1)).findRootCategories();
+        verify(categoryRepository, atLeastOnce()).findByParentId(any());
+    }
+
+    @Test
+    @DisplayName("활성 카테고리만 조회할 수 있다")
+    void shouldGetOnlyActiveCategories() {
+        // Given
+        String rootId = UUID.randomUUID().toString();
+        String activeChildId = UUID.randomUUID().toString();
+        String inactiveChildId = UUID.randomUUID().toString();
+
+        Category root = Category.createRoot(
+                CategoryId.of(rootId),
+                CategoryName.of("전자제품"),
+                1
+        );
+
+        Category activeChild = Category.createChild(
+                CategoryId.of(activeChildId),
+                CategoryName.of("노트북"),
+                CategoryId.of(rootId),
+                2,
+                1
+        );
+
+        Category inactiveChild = Category.createChild(
+                CategoryId.of(inactiveChildId),
+                CategoryName.of("데스크탑"),
+                CategoryId.of(rootId),
+                2,
+                2
+        );
+        inactiveChild.deactivate();
+
+        GetCategoryTreeRequest request = GetCategoryTreeRequest.builder()
+                .includeInactive(false)
+                .build();
+
+        when(categoryRepository.findRootCategories()).thenReturn(List.of(root));
+        when(categoryRepository.findByParentId(CategoryId.of(rootId)))
+                .thenReturn(Arrays.asList(activeChild, inactiveChild));
+        when(categoryRepository.findByParentId(CategoryId.of(activeChildId)))
+                .thenReturn(List.of());
+
+        // When
+        GetCategoryTreeResponse response = getCategoryTreeUseCase.execute(request);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getCategories()).hasSize(1);
+        
+        CategoryTreeNode electronics = response.getCategories().get(0);
+        assertThat(electronics.getChildren()).hasSize(1);
+        assertThat(electronics.getChildren().get(0).getName()).isEqualTo("노트북");
+    }
+
+    @Test
+    @DisplayName("비활성 카테고리를 포함하여 조회할 수 있다")
+    void shouldGetCategoriesIncludingInactive() {
+        // Given
+        String rootId = UUID.randomUUID().toString();
+        String activeChildId = UUID.randomUUID().toString();
+        String inactiveChildId = UUID.randomUUID().toString();
+
+        Category root = Category.createRoot(
+                CategoryId.of(rootId),
+                CategoryName.of("전자제품"),
+                1
+        );
+
+        Category activeChild = Category.createChild(
+                CategoryId.of(activeChildId),
+                CategoryName.of("노트북"),
+                CategoryId.of(rootId),
+                2,
+                1
+        );
+
+        Category inactiveChild = Category.createChild(
+                CategoryId.of(inactiveChildId),
+                CategoryName.of("데스크탑"),
+                CategoryId.of(rootId),
+                2,
+                2
+        );
+        inactiveChild.deactivate();
+
+        GetCategoryTreeRequest request = GetCategoryTreeRequest.builder()
+                .includeInactive(true)
+                .build();
+
+        when(categoryRepository.findRootCategories()).thenReturn(List.of(root));
+        when(categoryRepository.findByParentId(CategoryId.of(rootId)))
+                .thenReturn(Arrays.asList(activeChild, inactiveChild));
+        when(categoryRepository.findByParentId(CategoryId.of(activeChildId)))
+                .thenReturn(List.of());
+        when(categoryRepository.findByParentId(CategoryId.of(inactiveChildId)))
+                .thenReturn(List.of());
+
+        // When
+        GetCategoryTreeResponse response = getCategoryTreeUseCase.execute(request);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getCategories()).hasSize(1);
+        
+        CategoryTreeNode electronics = response.getCategories().get(0);
+        assertThat(electronics.getChildren()).hasSize(2);
+        assertThat(electronics.getChildren().stream()
+                .map(CategoryTreeNode::getName))
+                .containsExactlyInAnyOrder("노트북", "데스크탑");
+    }
+
+    @Test
+    @DisplayName("빈 카테고리 트리를 조회할 수 있다")
+    void shouldGetEmptyCategoryTree() {
+        // Given
+        GetCategoryTreeRequest request = GetCategoryTreeRequest.builder()
+                .includeInactive(false)
+                .build();
+
+        when(categoryRepository.findRootCategories()).thenReturn(List.of());
+
+        // When
+        GetCategoryTreeResponse response = getCategoryTreeUseCase.execute(request);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getCategories()).isEmpty();
+
+        verify(categoryRepository, times(1)).findRootCategories();
+        verify(categoryRepository, never()).findByParentId(any());
+    }
+
+    @Test
+    @DisplayName("정렬 순서에 따라 카테고리를 정렬하여 반환한다")
+    void shouldReturnCategoriesSortedBySortOrder() {
+        // Given
+        String rootId = UUID.randomUUID().toString();
+        String childId1 = UUID.randomUUID().toString();
+        String childId2 = UUID.randomUUID().toString();
+        String childId3 = UUID.randomUUID().toString();
+
+        Category root = Category.createRoot(
+                CategoryId.of(rootId),
+                CategoryName.of("전자제품"),
+                1
+        );
+
+        Category child1 = Category.createChild(
+                CategoryId.of(childId1),
+                CategoryName.of("스마트폰"),
+                CategoryId.of(rootId),
+                2,
+                3
+        );
+
+        Category child2 = Category.createChild(
+                CategoryId.of(childId2),
+                CategoryName.of("노트북"),
+                CategoryId.of(rootId),
+                2,
+                1
+        );
+
+        Category child3 = Category.createChild(
+                CategoryId.of(childId3),
+                CategoryName.of("태블릿"),
+                CategoryId.of(rootId),
+                2,
+                2
+        );
+
+        GetCategoryTreeRequest request = GetCategoryTreeRequest.builder()
+                .includeInactive(false)
+                .build();
+
+        when(categoryRepository.findRootCategories()).thenReturn(List.of(root));
+        when(categoryRepository.findByParentId(CategoryId.of(rootId)))
+                .thenReturn(Arrays.asList(child2, child3, child1)); // 순서 섞어서 반환
+        when(categoryRepository.findByParentId(CategoryId.of(childId1)))
+                .thenReturn(List.of());
+        when(categoryRepository.findByParentId(CategoryId.of(childId2)))
+                .thenReturn(List.of());
+        when(categoryRepository.findByParentId(CategoryId.of(childId3)))
+                .thenReturn(List.of());
+
+        // When
+        GetCategoryTreeResponse response = getCategoryTreeUseCase.execute(request);
+
+        // Then
+        assertThat(response).isNotNull();
+        CategoryTreeNode electronics = response.getCategories().get(0);
+        assertThat(electronics.getChildren()).hasSize(3);
+        assertThat(electronics.getChildren().get(0).getName()).isEqualTo("노트북");
+        assertThat(electronics.getChildren().get(1).getName()).isEqualTo("태블릿");
+        assertThat(electronics.getChildren().get(2).getName()).isEqualTo("스마트폰");
+    }
+}

--- a/core/product-core/src/test/java/com/commerce/product/application/usecase/UpdateCategoryUseCaseTest.java
+++ b/core/product-core/src/test/java/com/commerce/product/application/usecase/UpdateCategoryUseCaseTest.java
@@ -1,0 +1,315 @@
+package com.commerce.product.application.usecase;
+
+import com.commerce.product.domain.exception.CannotDeactivateCategoryException;
+import com.commerce.product.domain.exception.InvalidCategoryIdException;
+import com.commerce.product.domain.exception.InvalidCategoryNameException;
+import com.commerce.product.domain.model.Category;
+import com.commerce.product.domain.model.CategoryId;
+import com.commerce.product.domain.model.CategoryName;
+import com.commerce.product.domain.repository.CategoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateCategoryUseCaseTest {
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    private UpdateCategoryUseCase updateCategoryUseCase;
+
+    @BeforeEach
+    void setUp() {
+        updateCategoryUseCase = new UpdateCategoryService(categoryRepository);
+    }
+
+    @Test
+    @DisplayName("카테고리 이름을 수정할 수 있다")
+    void shouldUpdateCategoryName() {
+        // Given
+        String categoryId = UUID.randomUUID().toString();
+        String newName = "노트북 및 액세서리";
+        
+        Category category = Category.createRoot(
+                CategoryId.of(categoryId),
+                CategoryName.of("노트북"),
+                1
+        );
+
+        UpdateCategoryRequest request = UpdateCategoryRequest.builder()
+                .categoryId(categoryId)
+                .name(newName)
+                .build();
+
+        when(categoryRepository.findById(CategoryId.of(categoryId)))
+                .thenReturn(Optional.of(category));
+        when(categoryRepository.save(any(Category.class))).thenReturn(category);
+
+        // When
+        UpdateCategoryResponse response = updateCategoryUseCase.execute(request);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getCategoryId()).isEqualTo(categoryId);
+        assertThat(response.getName()).isEqualTo(newName);
+        assertThat(response.isActive()).isTrue();
+
+        verify(categoryRepository, times(1)).findById(CategoryId.of(categoryId));
+        verify(categoryRepository, times(1)).save(category);
+    }
+
+    @Test
+    @DisplayName("카테고리 정렬 순서를 수정할 수 있다")
+    void shouldUpdateCategorySortOrder() {
+        // Given
+        String categoryId = UUID.randomUUID().toString();
+        int newSortOrder = 5;
+        
+        Category category = Category.createRoot(
+                CategoryId.of(categoryId),
+                CategoryName.of("전자제품"),
+                1
+        );
+
+        UpdateCategoryRequest request = UpdateCategoryRequest.builder()
+                .categoryId(categoryId)
+                .sortOrder(newSortOrder)
+                .build();
+
+        when(categoryRepository.findById(CategoryId.of(categoryId)))
+                .thenReturn(Optional.of(category));
+        when(categoryRepository.save(any(Category.class))).thenReturn(category);
+
+        // When
+        UpdateCategoryResponse response = updateCategoryUseCase.execute(request);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getCategoryId()).isEqualTo(categoryId);
+        assertThat(response.getSortOrder()).isEqualTo(newSortOrder);
+
+        verify(categoryRepository, times(1)).save(category);
+    }
+
+    @Test
+    @DisplayName("카테고리를 활성화할 수 있다")
+    void shouldActivateCategory() {
+        // Given
+        String categoryId = UUID.randomUUID().toString();
+        
+        Category category = Category.createRoot(
+                CategoryId.of(categoryId),
+                CategoryName.of("전자제품"),
+                1
+        );
+        category.deactivate(); // 먼저 비활성화
+
+        UpdateCategoryRequest request = UpdateCategoryRequest.builder()
+                .categoryId(categoryId)
+                .isActive(true)
+                .build();
+
+        when(categoryRepository.findById(CategoryId.of(categoryId)))
+                .thenReturn(Optional.of(category));
+        when(categoryRepository.save(any(Category.class))).thenReturn(category);
+
+        // When
+        UpdateCategoryResponse response = updateCategoryUseCase.execute(request);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.isActive()).isTrue();
+
+        verify(categoryRepository, times(1)).save(category);
+    }
+
+    @Test
+    @DisplayName("활성 상품이 없는 카테고리를 비활성화할 수 있다")
+    void shouldDeactivateCategoryWithoutActiveProducts() {
+        // Given
+        String categoryId = UUID.randomUUID().toString();
+        
+        Category category = Category.createRoot(
+                CategoryId.of(categoryId),
+                CategoryName.of("전자제품"),
+                1
+        );
+
+        UpdateCategoryRequest request = UpdateCategoryRequest.builder()
+                .categoryId(categoryId)
+                .isActive(false)
+                .build();
+
+        when(categoryRepository.findById(CategoryId.of(categoryId)))
+                .thenReturn(Optional.of(category));
+        when(categoryRepository.hasActiveProducts(CategoryId.of(categoryId)))
+                .thenReturn(false);
+        when(categoryRepository.save(any(Category.class))).thenReturn(category);
+
+        // When
+        UpdateCategoryResponse response = updateCategoryUseCase.execute(request);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.isActive()).isFalse();
+
+        verify(categoryRepository, times(1)).hasActiveProducts(CategoryId.of(categoryId));
+        verify(categoryRepository, times(1)).save(category);
+    }
+
+    @Test
+    @DisplayName("활성 상품이 있는 카테고리는 비활성화할 수 없다")
+    void shouldNotDeactivateCategoryWithActiveProducts() {
+        // Given
+        String categoryId = UUID.randomUUID().toString();
+        
+        Category category = Category.createRoot(
+                CategoryId.of(categoryId),
+                CategoryName.of("전자제품"),
+                1
+        );
+
+        UpdateCategoryRequest request = UpdateCategoryRequest.builder()
+                .categoryId(categoryId)
+                .isActive(false)
+                .build();
+
+        when(categoryRepository.findById(CategoryId.of(categoryId)))
+                .thenReturn(Optional.of(category));
+        when(categoryRepository.hasActiveProducts(CategoryId.of(categoryId)))
+                .thenReturn(true);
+
+        // When & Then
+        assertThatThrownBy(() -> updateCategoryUseCase.execute(request))
+                .isInstanceOf(CannotDeactivateCategoryException.class)
+                .hasMessageContaining("Cannot deactivate category with active products");
+
+        verify(categoryRepository, times(1)).hasActiveProducts(CategoryId.of(categoryId));
+        verify(categoryRepository, never()).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("여러 속성을 동시에 수정할 수 있다")
+    void shouldUpdateMultipleAttributes() {
+        // Given
+        String categoryId = UUID.randomUUID().toString();
+        String newName = "스마트폰 및 액세서리";
+        int newSortOrder = 3;
+        
+        Category category = Category.createRoot(
+                CategoryId.of(categoryId),
+                CategoryName.of("스마트폰"),
+                1
+        );
+
+        UpdateCategoryRequest request = UpdateCategoryRequest.builder()
+                .categoryId(categoryId)
+                .name(newName)
+                .sortOrder(newSortOrder)
+                .build();
+
+        when(categoryRepository.findById(CategoryId.of(categoryId)))
+                .thenReturn(Optional.of(category));
+        when(categoryRepository.save(any(Category.class))).thenReturn(category);
+
+        // When
+        UpdateCategoryResponse response = updateCategoryUseCase.execute(request);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getName()).isEqualTo(newName);
+        assertThat(response.getSortOrder()).isEqualTo(newSortOrder);
+
+        verify(categoryRepository, times(1)).save(category);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 카테고리는 수정할 수 없다")
+    void shouldNotUpdateNonExistentCategory() {
+        // Given
+        String categoryId = UUID.randomUUID().toString();
+
+        UpdateCategoryRequest request = UpdateCategoryRequest.builder()
+                .categoryId(categoryId)
+                .name("새 이름")
+                .build();
+
+        when(categoryRepository.findById(CategoryId.of(categoryId)))
+                .thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> updateCategoryUseCase.execute(request))
+                .isInstanceOf(InvalidCategoryIdException.class)
+                .hasMessageContaining("Category not found");
+
+        verify(categoryRepository, times(1)).findById(CategoryId.of(categoryId));
+        verify(categoryRepository, never()).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("빈 이름으로 카테고리를 수정할 수 없다")
+    void shouldNotUpdateCategoryWithEmptyName() {
+        // Given
+        String categoryId = UUID.randomUUID().toString();
+        
+        Category category = Category.createRoot(
+                CategoryId.of(categoryId),
+                CategoryName.of("전자제품"),
+                1
+        );
+
+        UpdateCategoryRequest request = UpdateCategoryRequest.builder()
+                .categoryId(categoryId)
+                .name("")
+                .build();
+
+        when(categoryRepository.findById(CategoryId.of(categoryId)))
+                .thenReturn(Optional.of(category));
+
+        // When & Then
+        assertThatThrownBy(() -> updateCategoryUseCase.execute(request))
+                .isInstanceOf(InvalidCategoryNameException.class);
+
+        verify(categoryRepository, never()).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("음수 정렬 순서로 카테고리를 수정할 수 없다")
+    void shouldNotUpdateCategoryWithNegativeSortOrder() {
+        // Given
+        String categoryId = UUID.randomUUID().toString();
+        
+        Category category = Category.createRoot(
+                CategoryId.of(categoryId),
+                CategoryName.of("전자제품"),
+                1
+        );
+
+        UpdateCategoryRequest request = UpdateCategoryRequest.builder()
+                .categoryId(categoryId)
+                .sortOrder(-1)
+                .build();
+
+        when(categoryRepository.findById(CategoryId.of(categoryId)))
+                .thenReturn(Optional.of(category));
+
+        // When & Then
+        assertThatThrownBy(() -> updateCategoryUseCase.execute(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Sort order must be non-negative");
+
+        verify(categoryRepository, never()).save(any(Category.class));
+    }
+}

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -98,10 +98,10 @@ PRD 문서와 설계 문서를 기반으로 수립한 구현 작업 계획입니
 - [x] SearchProductsUseCase
 
 #### 5.3 Category UseCase
-- [ ] CreateCategoryUseCase
-- [ ] UpdateCategoryUseCase
-- [ ] AssignProductToCategoryUseCase
-- [ ] GetCategoryTreeUseCase
+- [x] CreateCategoryUseCase
+- [x] UpdateCategoryUseCase
+- [x] AssignProductToCategoryUseCase
+- [x] GetCategoryTreeUseCase
 
 ### 6. Domain Event 구현 ⭐⭐⭐
 이벤트 드리븐 아키텍처 기반


### PR DESCRIPTION
## Summary
- CreateCategoryUseCase: 카테고리 생성 기능 구현
- UpdateCategoryUseCase: 카테고리 수정 기능 구현  
- AssignProductToCategoryUseCase: 상품-카테고리 할당 기능 구현
- GetCategoryTreeUseCase: 카테고리 트리 조회 기능 구현

## Test plan
- [x] CreateCategoryUseCase 테스트 완료 (9개 테스트)
- [x] UpdateCategoryUseCase 테스트 완료 (9개 테스트)
- [x] AssignProductToCategoryUseCase 테스트 완료 (7개 테스트)
- [x] GetCategoryTreeUseCase 테스트 완료 (5개 테스트)
- [x] 모든 테스트 성공 확인

Closes #59

🤖 Generated with Claude Code