### PR TITLE
feat(#66): 7 Persistence Adapter - 7.2 Repository Adapter 구현

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -130,9 +130,9 @@ JPA 기반 영속성 계층
 - [x] Category JPA Entity
 
 #### 7.2 Repository Adapter 구현
-- [ ] InventoryRepositoryAdapter
-- [ ] ProductRepositoryAdapter
-- [ ] CategoryRepositoryAdapter
+- [x] InventoryRepositoryAdapter
+- [x] ProductRepositoryAdapter (기존 구현 사용)
+- [x] CategoryRepositoryAdapter
 
 #### 7.3 Mapper 구현
 - [ ] Domain ↔ JPA Entity 매핑

--- a/infrastructure/product-persistence/build.gradle
+++ b/infrastructure/product-persistence/build.gradle
@@ -33,6 +33,12 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
     runtimeOnly 'com.h2database:h2' // for testing
     
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
@@ -49,4 +55,23 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// QueryDSL 설정
+def querydslDir = "${buildDir}/generated"
+
+sourceSets {
+    main {
+        java {
+            srcDirs += querydslDir
+        }
+    }
+}
+
+tasks.withType(JavaCompile) {
+    options.generatedSourceOutputDirectory = file(querydslDir)
+}
+
+clean {
+    delete file(querydslDir)
 }

--- a/infrastructure/product-persistence/build.gradle
+++ b/infrastructure/product-persistence/build.gradle
@@ -1,0 +1,52 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.2.0' apply false
+    id 'io.spring.dependency-management' version '1.1.4'
+}
+
+group = 'com.commerce.product'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '17'
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.boot:spring-boot-dependencies:3.2.0"
+    }
+}
+
+dependencies {
+    implementation project(':product-core')
+    implementation project(':common')
+    
+    // Spring Boot
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    
+    // Database
+    runtimeOnly 'org.postgresql:postgresql'
+    runtimeOnly 'com.h2database:h2' // for testing
+    
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    
+    // Testing
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
+    testImplementation 'org.testcontainers:testcontainers:1.19.3'
+    testImplementation 'org.testcontainers:postgresql:1.19.3'
+    testImplementation 'org.testcontainers:junit-jupiter:1.19.3'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/adapter/CategoryRepositoryAdapter.java
+++ b/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/adapter/CategoryRepositoryAdapter.java
@@ -1,0 +1,161 @@
+package com.commerce.product.infrastructure.persistence.adapter;
+
+import com.commerce.product.domain.model.Category;
+import com.commerce.product.domain.model.CategoryId;
+import com.commerce.product.domain.repository.CategoryRepository;
+import com.commerce.product.infrastructure.persistence.entity.CategoryJpaEntity;
+import com.commerce.product.infrastructure.persistence.repository.CategoryJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Category 도메인 리포지토리의 JPA 구현체
+ * 카테고리 정보의 영속성을 관리합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CategoryRepositoryAdapter implements CategoryRepository {
+    
+    private final CategoryJpaRepository categoryJpaRepository;
+    
+    @Override
+    @Transactional
+    public Category save(Category category) {
+        CategoryJpaEntity entity = CategoryJpaEntity.fromDomainModel(category);
+        CategoryJpaEntity savedEntity = categoryJpaRepository.save(entity);
+        
+        // 자식 카테고리들도 함께 저장
+        if (!category.getChildren().isEmpty()) {
+            for (Category child : category.getChildren()) {
+                save(child);
+            }
+        }
+        
+        return savedEntity.toDomainModel();
+    }
+    
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<Category> findById(CategoryId id) {
+        return categoryJpaRepository.findByIdWithChildren(id.value())
+                .map(CategoryJpaEntity::toDomainModelWithChildren);
+    }
+    
+    @Override
+    @Transactional(readOnly = true)
+    public List<Category> findRootCategories() {
+        return categoryJpaRepository.findRootCategories().stream()
+                .map(CategoryJpaEntity::toDomainModelWithChildren)
+                .collect(Collectors.toList());
+    }
+    
+    @Override
+    @Transactional(readOnly = true)
+    public List<Category> findByParentId(CategoryId parentId) {
+        return categoryJpaRepository.findByParentId(parentId.value()).stream()
+                .map(CategoryJpaEntity::toDomainModelWithChildren)
+                .collect(Collectors.toList());
+    }
+    
+    @Override
+    @Transactional(readOnly = true)
+    public List<Category> findActiveCategories() {
+        return categoryJpaRepository.findActiveCategories().stream()
+                .map(CategoryJpaEntity::toDomainModel)
+                .collect(Collectors.toList());
+    }
+    
+    @Override
+    @Transactional(readOnly = true)
+    public List<Category> findCategoryPath(CategoryId leafCategoryId) {
+        return categoryJpaRepository.findCategoryPath(leafCategoryId.value()).stream()
+                .map(CategoryJpaEntity::toDomainModel)
+                .collect(Collectors.toList());
+    }
+    
+    @Override
+    @Transactional
+    public void delete(Category category) {
+        categoryJpaRepository.findById(category.getId().value())
+                .ifPresent(entity -> {
+                    entity.markAsDeleted();
+                    categoryJpaRepository.save(entity);
+                    
+                    // 자식 카테고리들도 함께 삭제 (soft delete)
+                    if (!category.getChildren().isEmpty()) {
+                        for (Category child : category.getChildren()) {
+                            delete(child);
+                        }
+                    }
+                });
+    }
+    
+    @Override
+    @Transactional(readOnly = true)
+    public boolean hasActiveProducts(CategoryId categoryId) {
+        return categoryJpaRepository.hasActiveProducts(categoryId.value());
+    }
+    
+    @Override
+    @Transactional(readOnly = true)
+    public List<Category> findAll() {
+        // 전체 카테고리를 계층 구조로 조회
+        List<CategoryJpaEntity> rootEntities = categoryJpaRepository.findAllWithHierarchy();
+        return rootEntities.stream()
+                .map(CategoryJpaEntity::toDomainModelWithChildren)
+                .collect(Collectors.toList());
+    }
+    
+    @Override
+    @Transactional(readOnly = true)
+    public List<Category> findAllById(List<CategoryId> categoryIds) {
+        if (categoryIds == null || categoryIds.isEmpty()) {
+            return List.of();
+        }
+        
+        List<String> ids = categoryIds.stream()
+                .map(CategoryId::value)
+                .distinct()
+                .collect(Collectors.toList());
+                
+        return categoryJpaRepository.findAllByIdIn(ids).stream()
+                .map(CategoryJpaEntity::toDomainModel)
+                .collect(Collectors.toList());
+    }
+    
+    @Transactional(readOnly = true)
+    public long count() {
+        return categoryJpaRepository.count();
+    }
+    
+    @Override
+    @Transactional(readOnly = true) 
+    public boolean existsById(CategoryId id) {
+        return categoryJpaRepository.existsById(id.value());
+    }
+    
+    @Override
+    @Transactional
+    public void deleteById(CategoryId id) {
+        categoryJpaRepository.findById(id.value())
+                .ifPresent(entity -> {
+                    entity.markAsDeleted();
+                    categoryJpaRepository.save(entity);
+                });
+    }
+    
+    @Override
+    @Transactional
+    public List<Category> saveAll(List<Category> entities) {
+        return entities.stream()
+                .map(this::save)
+                .collect(Collectors.toList());
+    }
+}

--- a/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/adapter/InventoryRepositoryAdapter.java
+++ b/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/adapter/InventoryRepositoryAdapter.java
@@ -1,0 +1,286 @@
+package com.commerce.product.infrastructure.persistence.adapter;
+
+import com.commerce.common.domain.model.Quantity;
+import com.commerce.product.domain.model.inventory.Inventory;
+import com.commerce.product.domain.model.inventory.SkuId;
+import com.commerce.product.domain.repository.InventoryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Inventory 서비스와의 통신을 담당하는 Adapter
+ * Product 서비스에서 Inventory 서비스의 재고 정보를 조회/수정할 때 사용
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class InventoryRepositoryAdapter implements InventoryRepository {
+    
+    private final WebClient inventoryServiceWebClient;
+    private static final Duration TIMEOUT = Duration.ofSeconds(5);
+    
+    @Override
+    public int getAvailableQuantity(String skuId) {
+        try {
+            return inventoryServiceWebClient
+                    .get()
+                    .uri("/api/inventory/{skuId}", skuId)
+                    .retrieve()
+                    .onStatus(
+                            status -> status.equals(HttpStatus.NOT_FOUND),
+                            response -> Mono.empty()
+                    )
+                    .bodyToMono(InventoryResponse.class)
+                    .map(InventoryResponse::getAvailableQuantity)
+                    .timeout(TIMEOUT)
+                    .doOnError(error -> log.error("Failed to get available quantity for SKU: {}", skuId, error))
+                    .onErrorReturn(0)
+                    .block();
+        } catch (Exception e) {
+            log.error("Error getting available quantity for SKU: {}", skuId, e);
+            return 0;
+        }
+    }
+    
+    @Override
+    public String reserveStock(String skuId, int quantity, String orderId) {
+        try {
+            ReservationRequest request = ReservationRequest.builder()
+                    .skuId(skuId)
+                    .quantity(quantity)
+                    .orderId(orderId)
+                    .ttl(300) // 5 minutes default TTL
+                    .build();
+                    
+            return inventoryServiceWebClient
+                    .post()
+                    .uri("/api/inventory/reservations")
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(ReservationResponse.class)
+                    .map(ReservationResponse::getReservationId)
+                    .timeout(TIMEOUT)
+                    .doOnError(error -> log.error("Failed to reserve stock for SKU: {}, quantity: {}", skuId, quantity, error))
+                    .onErrorResume(error -> Mono.error(new RuntimeException("재고 예약에 실패했습니다.")))
+                    .block();
+        } catch (Exception e) {
+            log.error("Error reserving stock for SKU: {}, quantity: {}", skuId, quantity, e);
+            throw new RuntimeException("재고 예약 중 오류가 발생했습니다.", e);
+        }
+    }
+    
+    @Override
+    public void releaseReservation(String reservationId) {
+        try {
+            inventoryServiceWebClient
+                    .delete()
+                    .uri("/api/inventory/reservations/{id}", reservationId)
+                    .retrieve()
+                    .toBodilessEntity()
+                    .timeout(TIMEOUT)
+                    .doOnError(error -> log.error("Failed to release reservation: {}", reservationId, error))
+                    .block();
+        } catch (Exception e) {
+            log.error("Error releasing reservation: {}", reservationId, e);
+            // 예약 해제 실패는 로깅만 하고 예외를 전파하지 않음
+            // 백그라운드 프로세스가 만료된 예약을 처리할 것임
+        }
+    }
+    
+    @Override
+    public Optional<Inventory> findBySkuId(SkuId skuId) {
+        try {
+            return inventoryServiceWebClient
+                    .get()
+                    .uri("/api/inventory/{skuId}", skuId.value())
+                    .retrieve()
+                    .onStatus(
+                            status -> status.equals(HttpStatus.NOT_FOUND),
+                            response -> Mono.empty()
+                    )
+                    .bodyToMono(InventoryResponse.class)
+                    .map(response -> new InventoryImpl(
+                            new SkuId(response.getSkuId()),
+                            response.getTotalQuantity(),
+                            response.getReservedQuantity(),
+                            response.getAvailableQuantity()
+                    ))
+                    .map(inv -> (Inventory) inv)
+                    .timeout(TIMEOUT)
+                    .blockOptional();
+        } catch (Exception e) {
+            log.error("Error finding inventory for SKU: {}", skuId.value(), e);
+            return Optional.empty();
+        }
+    }
+    
+    @Override
+    public void save(Inventory inventory) {
+        // Product 서비스는 Inventory를 직접 저장하지 않음
+        // 이 메서드는 테스트 목적으로만 사용될 수 있음
+        throw new UnsupportedOperationException("Product service cannot directly save inventory");
+    }
+    
+    @Override
+    public Map<SkuId, Inventory> findBySkuIds(List<SkuId> skuIds) {
+        if (skuIds == null || skuIds.isEmpty()) {
+            return Map.of();
+        }
+        
+        try {
+            List<String> skuIdStrings = skuIds.stream()
+                    .map(SkuId::value)
+                    .distinct()
+                    .collect(Collectors.toList());
+            
+            return Flux.fromIterable(skuIdStrings)
+                    .flatMap(skuId -> inventoryServiceWebClient
+                            .get()
+                            .uri("/api/inventory/{skuId}", skuId)
+                            .retrieve()
+                            .onStatus(
+                                    status -> status.equals(HttpStatus.NOT_FOUND),
+                                    response -> Mono.empty()
+                            )
+                            .bodyToMono(InventoryResponse.class)
+                            .onErrorResume(error -> {
+                                log.error("Error fetching inventory for SKU: {}", skuId, error);
+                                return Mono.empty();
+                            })
+                    )
+                    .collectMap(
+                            response -> new SkuId(response.getSkuId()),
+                            response -> (Inventory) new InventoryImpl(
+                                    new SkuId(response.getSkuId()),
+                                    response.getTotalQuantity(),
+                                    response.getReservedQuantity(),
+                                    response.getAvailableQuantity()
+                            )
+                    )
+                    .timeout(TIMEOUT)
+                    .block();
+        } catch (Exception e) {
+            log.error("Error finding inventory for multiple SKUs", e);
+            return Map.of();
+        }
+    }
+    
+    /**
+     * Inventory 서비스 응답 DTO
+     */
+    @lombok.Data
+    @lombok.NoArgsConstructor
+    @lombok.AllArgsConstructor
+    @lombok.Builder
+    private static class InventoryResponse {
+        private String skuId;
+        private int totalQuantity;
+        private int reservedQuantity;
+        private int availableQuantity;
+    }
+    
+    /**
+     * 재고 예약 요청 DTO
+     */
+    @lombok.Data
+    @lombok.NoArgsConstructor
+    @lombok.AllArgsConstructor
+    @lombok.Builder
+    private static class ReservationRequest {
+        private String skuId;
+        private int quantity;
+        private String orderId;
+        private int ttl;
+    }
+    
+    /**
+     * 재고 예약 응답 DTO
+     */
+    @lombok.Data
+    @lombok.NoArgsConstructor
+    @lombok.AllArgsConstructor
+    @lombok.Builder
+    private static class ReservationResponse {
+        private String reservationId;
+        private String skuId;
+        private int quantity;
+        private String orderId;
+        private String expiresAt;
+    }
+    
+    /**
+     * Inventory 인터페이스의 구현체
+     */
+    @lombok.RequiredArgsConstructor
+    @lombok.Getter
+    private static class InventoryImpl implements Inventory {
+        private final SkuId skuId;
+        private final int totalQuantity;
+        private final int reservedQuantity;
+        private final int availableQuantity;
+        
+        @Override
+        public Quantity getAvailableQuantity() {
+            return Quantity.of(availableQuantity);
+        }
+    }
+    
+    public boolean existsById(Object id) {
+        // InventoryRepository는 Repository 인터페이스를 상속받지 않으므로
+        // 이 메소드는 필요하지 않음
+        throw new UnsupportedOperationException("existsById is not supported in InventoryRepository");
+    }
+    
+    public long count() {
+        // Product 도메인에서는 이 메소드를 사용하지 않음
+        throw new UnsupportedOperationException("count is not supported in InventoryRepository");
+    }
+    
+    public void deleteById(Object id) {
+        // Product 도메인에서는 inventory를 직접 삭제하지 않음
+        throw new UnsupportedOperationException("deleteById is not supported in InventoryRepository");
+    }
+    
+    public List<?> findAll() {
+        // Product 도메인에서는 이 메소드를 사용하지 않음
+        throw new UnsupportedOperationException("findAll is not supported in InventoryRepository");
+    }
+    
+    public void delete(Object entity) {
+        // Product 도메인에서는 inventory를 직접 삭제하지 않음
+        throw new UnsupportedOperationException("delete is not supported in InventoryRepository");
+    }
+    
+    @Override
+    public Optional<Inventory> findById(Object id) {
+        if (id instanceof SkuId) {
+            return findBySkuId((SkuId) id);
+        }
+        return Optional.empty();
+    }
+    
+    @Override
+    public Inventory save(Object entity) {
+        if (entity instanceof Inventory) {
+            save((Inventory) entity);
+            return (Inventory) entity;
+        }
+        throw new IllegalArgumentException("Entity must be an Inventory instance");
+    }
+    
+    @Override
+    public List<Inventory> saveAll(List entities) {
+        throw new UnsupportedOperationException("saveAll is not supported in InventoryRepository");
+    }
+}

--- a/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/config/QueryDslConfig.java
+++ b/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.commerce.product.infrastructure.persistence.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    
+    @PersistenceContext
+    private EntityManager entityManager;
+    
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/config/WebClientConfig.java
+++ b/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/config/WebClientConfig.java
@@ -1,0 +1,66 @@
+package com.commerce.product.infrastructure.persistence.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * WebClient 설정
+ * 다른 마이크로서비스와의 통신을 위한 WebClient 빈을 설정합니다.
+ */
+@Configuration
+public class WebClientConfig {
+    
+    @Value("${inventory.service.url:http://inventory-service}")
+    private String inventoryServiceUrl;
+    
+    @Value("${webclient.timeout.connect:5000}")
+    private int connectTimeout;
+    
+    @Value("${webclient.timeout.read:5000}")
+    private int readTimeout;
+    
+    @Value("${webclient.timeout.write:5000}")
+    private int writeTimeout;
+    
+    @Value("${webclient.buffer.size:1048576}")  // 1MB
+    private int bufferSize;
+    
+    /**
+     * Inventory 서비스와 통신하기 위한 WebClient
+     */
+    @Bean
+    public WebClient inventoryServiceWebClient(WebClient.Builder webClientBuilder) {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeout)
+                .responseTimeout(Duration.ofMillis(readTimeout))
+                .doOnConnected(conn -> 
+                    conn.addHandlerLast(new ReadTimeoutHandler(readTimeout, TimeUnit.MILLISECONDS))
+                        .addHandlerLast(new WriteTimeoutHandler(writeTimeout, TimeUnit.MILLISECONDS)));
+        
+        ExchangeStrategies exchangeStrategies = ExchangeStrategies.builder()
+                .codecs(configurer -> configurer.defaultCodecs()
+                        .maxInMemorySize(bufferSize))
+                .build();
+        
+        return webClientBuilder
+                .baseUrl(inventoryServiceUrl)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .exchangeStrategies(exchangeStrategies)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+}

--- a/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/repository/CategoryJpaRepository.java
+++ b/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/repository/CategoryJpaRepository.java
@@ -32,23 +32,20 @@ public interface CategoryJpaRepository extends JpaRepository<CategoryJpaEntity, 
     
     /**
      * ID로 카테고리를 자식들과 함께 조회합니다.
+     * QueryDSL을 사용하는 메서드는 CategoryJpaRepositoryCustom 인터페이스에서 제공됩니다.
      */
-    @Query("SELECT DISTINCT c FROM CategoryJpaEntity c LEFT JOIN FETCH c.children WHERE c.id = :id AND c.deletedAt IS NULL")
-    Optional<CategoryJpaEntity> findByIdWithChildren(@Param("id") String id);
+    default Optional<CategoryJpaEntity> findByIdWithChildren(String id) {
+        return findByIdWithChildrenQueryDsl(id);
+    }
     
     
     /**
      * 카테고리에 활성 상품이 있는지 확인합니다.
+     * QueryDSL을 사용하는 메서드는 CategoryJpaRepositoryCustom 인터페이스에서 제공됩니다.
      */
-    @Query("""
-            SELECT CASE WHEN COUNT(pc) > 0 THEN true ELSE false END
-            FROM ProductCategoryJpaEntity pc
-            JOIN pc.product p
-            WHERE pc.category.id = :categoryId 
-            AND p.status = 'ACTIVE'
-            AND p.deletedAt IS NULL
-            """)
-    boolean hasActiveProducts(@Param("categoryId") String categoryId);
+    default boolean hasActiveProducts(String categoryId) {
+        return hasActiveProductsQueryDsl(categoryId);
+    }
     
     /**
      * 여러 ID로 카테고리들을 조회합니다.
@@ -58,7 +55,9 @@ public interface CategoryJpaRepository extends JpaRepository<CategoryJpaEntity, 
     
     /**
      * 모든 카테고리를 계층 구조로 조회합니다.
+     * QueryDSL을 사용하는 메서드는 CategoryJpaRepositoryCustom 인터페이스에서 제공됩니다.
      */
-    @Query("SELECT DISTINCT c FROM CategoryJpaEntity c LEFT JOIN FETCH c.children WHERE c.parentId IS NULL AND c.deletedAt IS NULL ORDER BY c.sortOrder ASC, c.name ASC")
-    List<CategoryJpaEntity> findAllWithHierarchy();
+    default List<CategoryJpaEntity> findAllWithHierarchy() {
+        return findAllWithHierarchyQueryDsl();
+    }
 }

--- a/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/repository/CategoryJpaRepository.java
+++ b/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/repository/CategoryJpaRepository.java
@@ -2,8 +2,6 @@ package com.commerce.product.infrastructure.persistence.repository;
 
 import com.commerce.product.infrastructure.persistence.entity.CategoryJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -15,33 +13,33 @@ public interface CategoryJpaRepository extends JpaRepository<CategoryJpaEntity, 
     /**
      * 최상위 카테고리 목록을 조회합니다.
      */
-    @Query("SELECT c FROM CategoryJpaEntity c WHERE c.parentId IS NULL AND c.deletedAt IS NULL ORDER BY c.sortOrder ASC, c.name ASC")
-    List<CategoryJpaEntity> findRootCategories();
+    default List<CategoryJpaEntity> findRootCategories() {
+        return findRootCategoriesQueryDsl();
+    }
     
     /**
      * 특정 부모 카테고리의 하위 카테고리 목록을 조회합니다.
      */
-    @Query("SELECT c FROM CategoryJpaEntity c WHERE c.parentId = :parentId AND c.deletedAt IS NULL ORDER BY c.sortOrder ASC, c.name ASC")
-    List<CategoryJpaEntity> findByParentId(@Param("parentId") String parentId);
+    default List<CategoryJpaEntity> findByParentId(String parentId) {
+        return findByParentIdQueryDsl(parentId);
+    }
     
     /**
      * 활성 상태의 카테고리 목록을 조회합니다.
      */
-    @Query("SELECT c FROM CategoryJpaEntity c WHERE c.isActive = true AND c.deletedAt IS NULL ORDER BY c.level ASC, c.sortOrder ASC, c.name ASC")
-    List<CategoryJpaEntity> findActiveCategories();
+    default List<CategoryJpaEntity> findActiveCategories() {
+        return findActiveCategoriesQueryDsl();
+    }
     
     /**
      * ID로 카테고리를 자식들과 함께 조회합니다.
-     * QueryDSL을 사용하는 메서드는 CategoryJpaRepositoryCustom 인터페이스에서 제공됩니다.
      */
     default Optional<CategoryJpaEntity> findByIdWithChildren(String id) {
         return findByIdWithChildrenQueryDsl(id);
     }
     
-    
     /**
      * 카테고리에 활성 상품이 있는지 확인합니다.
-     * QueryDSL을 사용하는 메서드는 CategoryJpaRepositoryCustom 인터페이스에서 제공됩니다.
      */
     default boolean hasActiveProducts(String categoryId) {
         return hasActiveProductsQueryDsl(categoryId);
@@ -50,12 +48,12 @@ public interface CategoryJpaRepository extends JpaRepository<CategoryJpaEntity, 
     /**
      * 여러 ID로 카테고리들을 조회합니다.
      */
-    @Query("SELECT c FROM CategoryJpaEntity c WHERE c.id IN :categoryIds AND c.deletedAt IS NULL")
-    List<CategoryJpaEntity> findAllByIdIn(@Param("categoryIds") List<String> categoryIds);
+    default List<CategoryJpaEntity> findAllByIdIn(List<String> categoryIds) {
+        return findAllByIdInQueryDsl(categoryIds);
+    }
     
     /**
      * 모든 카테고리를 계층 구조로 조회합니다.
-     * QueryDSL을 사용하는 메서드는 CategoryJpaRepositoryCustom 인터페이스에서 제공됩니다.
      */
     default List<CategoryJpaEntity> findAllWithHierarchy() {
         return findAllWithHierarchyQueryDsl();

--- a/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/repository/CategoryJpaRepository.java
+++ b/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/repository/CategoryJpaRepository.java
@@ -1,0 +1,79 @@
+package com.commerce.product.infrastructure.persistence.repository;
+
+import com.commerce.product.infrastructure.persistence.entity.CategoryJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CategoryJpaRepository extends JpaRepository<CategoryJpaEntity, String> {
+    
+    /**
+     * 최상위 카테고리 목록을 조회합니다.
+     */
+    @Query("SELECT c FROM CategoryJpaEntity c WHERE c.parentId IS NULL AND c.deletedAt IS NULL ORDER BY c.sortOrder ASC, c.name ASC")
+    List<CategoryJpaEntity> findRootCategories();
+    
+    /**
+     * 특정 부모 카테고리의 하위 카테고리 목록을 조회합니다.
+     */
+    @Query("SELECT c FROM CategoryJpaEntity c WHERE c.parentId = :parentId AND c.deletedAt IS NULL ORDER BY c.sortOrder ASC, c.name ASC")
+    List<CategoryJpaEntity> findByParentId(@Param("parentId") String parentId);
+    
+    /**
+     * 활성 상태의 카테고리 목록을 조회합니다.
+     */
+    @Query("SELECT c FROM CategoryJpaEntity c WHERE c.isActive = true AND c.deletedAt IS NULL ORDER BY c.level ASC, c.sortOrder ASC, c.name ASC")
+    List<CategoryJpaEntity> findActiveCategories();
+    
+    /**
+     * ID로 카테고리를 자식들과 함께 조회합니다.
+     */
+    @Query("SELECT DISTINCT c FROM CategoryJpaEntity c LEFT JOIN FETCH c.children WHERE c.id = :id AND c.deletedAt IS NULL")
+    Optional<CategoryJpaEntity> findByIdWithChildren(@Param("id") String id);
+    
+    /**
+     * 카테고리 경로를 조회합니다.
+     * 리프 카테고리부터 루트까지의 경로를 반환합니다.
+     */
+    @Query(value = """
+            WITH RECURSIVE category_path AS (
+                SELECT c.* FROM categories c WHERE c.id = :leafCategoryId AND c.deleted_at IS NULL
+                UNION ALL
+                SELECT c.* FROM categories c 
+                INNER JOIN category_path cp ON c.id = cp.parent_id
+                WHERE c.deleted_at IS NULL
+            )
+            SELECT * FROM category_path ORDER BY level DESC
+            """, nativeQuery = true)
+    List<CategoryJpaEntity> findCategoryPath(@Param("leafCategoryId") String leafCategoryId);
+    
+    /**
+     * 카테고리에 활성 상품이 있는지 확인합니다.
+     */
+    @Query("""
+            SELECT CASE WHEN COUNT(pc) > 0 THEN true ELSE false END
+            FROM ProductCategoryJpaEntity pc
+            JOIN pc.product p
+            WHERE pc.category.id = :categoryId 
+            AND p.status = 'ACTIVE'
+            AND p.deletedAt IS NULL
+            """)
+    boolean hasActiveProducts(@Param("categoryId") String categoryId);
+    
+    /**
+     * 여러 ID로 카테고리들을 조회합니다.
+     */
+    @Query("SELECT c FROM CategoryJpaEntity c WHERE c.id IN :categoryIds AND c.deletedAt IS NULL")
+    List<CategoryJpaEntity> findAllByIdIn(@Param("categoryIds") List<String> categoryIds);
+    
+    /**
+     * 모든 카테고리를 계층 구조로 조회합니다.
+     */
+    @Query("SELECT DISTINCT c FROM CategoryJpaEntity c LEFT JOIN FETCH c.children WHERE c.parentId IS NULL AND c.deletedAt IS NULL ORDER BY c.sortOrder ASC, c.name ASC")
+    List<CategoryJpaEntity> findAllWithHierarchy();
+}

--- a/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/repository/CategoryJpaRepository.java
+++ b/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/repository/CategoryJpaRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface CategoryJpaRepository extends JpaRepository<CategoryJpaEntity, String> {
+public interface CategoryJpaRepository extends JpaRepository<CategoryJpaEntity, String>, CategoryJpaRepositoryCustom {
     
     /**
      * 최상위 카테고리 목록을 조회합니다.
@@ -36,21 +36,6 @@ public interface CategoryJpaRepository extends JpaRepository<CategoryJpaEntity, 
     @Query("SELECT DISTINCT c FROM CategoryJpaEntity c LEFT JOIN FETCH c.children WHERE c.id = :id AND c.deletedAt IS NULL")
     Optional<CategoryJpaEntity> findByIdWithChildren(@Param("id") String id);
     
-    /**
-     * 카테고리 경로를 조회합니다.
-     * 리프 카테고리부터 루트까지의 경로를 반환합니다.
-     */
-    @Query(value = """
-            WITH RECURSIVE category_path AS (
-                SELECT c.* FROM categories c WHERE c.id = :leafCategoryId AND c.deleted_at IS NULL
-                UNION ALL
-                SELECT c.* FROM categories c 
-                INNER JOIN category_path cp ON c.id = cp.parent_id
-                WHERE c.deleted_at IS NULL
-            )
-            SELECT * FROM category_path ORDER BY level DESC
-            """, nativeQuery = true)
-    List<CategoryJpaEntity> findCategoryPath(@Param("leafCategoryId") String leafCategoryId);
     
     /**
      * 카테고리에 활성 상품이 있는지 확인합니다.

--- a/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/repository/CategoryJpaRepositoryCustom.java
+++ b/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/repository/CategoryJpaRepositoryCustom.java
@@ -26,4 +26,24 @@ public interface CategoryJpaRepositoryCustom {
      * 리프 카테고리부터 루트까지의 경로를 조회합니다.
      */
     List<CategoryJpaEntity> findCategoryPath(String leafCategoryId);
+    
+    /**
+     * 최상위 카테고리 목록을 조회합니다.
+     */
+    List<CategoryJpaEntity> findRootCategoriesQueryDsl();
+    
+    /**
+     * 특정 부모 카테고리의 하위 카테고리 목록을 조회합니다.
+     */
+    List<CategoryJpaEntity> findByParentIdQueryDsl(String parentId);
+    
+    /**
+     * 활성 상태의 카테고리 목록을 조회합니다.
+     */
+    List<CategoryJpaEntity> findActiveCategoriesQueryDsl();
+    
+    /**
+     * 여러 ID로 카테고리들을 조회합니다.
+     */
+    List<CategoryJpaEntity> findAllByIdInQueryDsl(List<String> categoryIds);
 }

--- a/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/repository/CategoryJpaRepositoryCustom.java
+++ b/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/repository/CategoryJpaRepositoryCustom.java
@@ -3,14 +3,27 @@ package com.commerce.product.infrastructure.persistence.repository;
 import com.commerce.product.infrastructure.persistence.entity.CategoryJpaEntity;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CategoryJpaRepositoryCustom {
+    
     /**
-     * 리프 카테고리부터 루트까지의 전체 경로를 조회합니다.
-     * 재귀 CTE를 사용하여 하위 카테고리부터 상위 카테고리까지 순서대로 조회합니다.
-     * 
-     * @param leafCategoryId 리프 카테고리 ID
-     * @return 카테고리 경로 (하위에서 상위 순서)
+     * ID로 카테고리를 자식들과 함께 조회합니다.
+     */
+    Optional<CategoryJpaEntity> findByIdWithChildrenQueryDsl(String id);
+    
+    /**
+     * 카테고리에 활성 상품이 있는지 확인합니다.
+     */
+    boolean hasActiveProductsQueryDsl(String categoryId);
+    
+    /**
+     * 모든 카테고리를 계층 구조로 조회합니다.
+     */
+    List<CategoryJpaEntity> findAllWithHierarchyQueryDsl();
+    
+    /**
+     * 리프 카테고리부터 루트까지의 경로를 조회합니다.
      */
     List<CategoryJpaEntity> findCategoryPath(String leafCategoryId);
 }

--- a/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/repository/CategoryJpaRepositoryCustom.java
+++ b/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/repository/CategoryJpaRepositoryCustom.java
@@ -1,0 +1,16 @@
+package com.commerce.product.infrastructure.persistence.repository;
+
+import com.commerce.product.infrastructure.persistence.entity.CategoryJpaEntity;
+
+import java.util.List;
+
+public interface CategoryJpaRepositoryCustom {
+    /**
+     * 리프 카테고리부터 루트까지의 전체 경로를 조회합니다.
+     * 재귀 CTE를 사용하여 하위 카테고리부터 상위 카테고리까지 순서대로 조회합니다.
+     * 
+     * @param leafCategoryId 리프 카테고리 ID
+     * @return 카테고리 경로 (하위에서 상위 순서)
+     */
+    List<CategoryJpaEntity> findCategoryPath(String leafCategoryId);
+}

--- a/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/repository/CategoryJpaRepositoryImpl.java
+++ b/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/repository/CategoryJpaRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.commerce.product.infrastructure.persistence.repository;
+
+import com.commerce.product.infrastructure.persistence.entity.CategoryJpaEntity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CategoryJpaRepositoryImpl implements CategoryJpaRepositoryCustom {
+    
+    @PersistenceContext
+    private EntityManager entityManager;
+    
+    private static final String FIND_CATEGORY_PATH_QUERY = """
+            WITH RECURSIVE category_path AS (
+                SELECT c.*, 0 as path_level 
+                FROM categories c 
+                WHERE c.id = :leafCategoryId 
+                  AND c.deleted_at IS NULL
+                
+                UNION ALL
+                
+                SELECT c.*, cp.path_level + 1 
+                FROM categories c 
+                INNER JOIN category_path cp ON c.id = cp.parent_id
+                WHERE c.deleted_at IS NULL
+            )
+            SELECT * FROM category_path 
+            ORDER BY path_level DESC
+            """;
+    
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<CategoryJpaEntity> findCategoryPath(String leafCategoryId) {
+        Query nativeQuery = entityManager.createNativeQuery(
+            FIND_CATEGORY_PATH_QUERY, 
+            CategoryJpaEntity.class
+        );
+        nativeQuery.setParameter("leafCategoryId", leafCategoryId);
+        
+        return nativeQuery.getResultList();
+    }
+}

--- a/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/repository/CategoryJpaRepositoryImpl.java
+++ b/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/repository/CategoryJpaRepositoryImpl.java
@@ -1,48 +1,94 @@
 package com.commerce.product.infrastructure.persistence.repository;
 
+import com.commerce.product.domain.model.ProductStatus;
 import com.commerce.product.infrastructure.persistence.entity.CategoryJpaEntity;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
-import jakarta.persistence.Query;
+import com.commerce.product.infrastructure.persistence.entity.QCategoryJpaEntity;
+import com.commerce.product.infrastructure.persistence.entity.QProductCategoryJpaEntity;
+import com.commerce.product.infrastructure.persistence.entity.QProductJpaEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
 public class CategoryJpaRepositoryImpl implements CategoryJpaRepositoryCustom {
     
-    @PersistenceContext
-    private EntityManager entityManager;
-    
-    private static final String FIND_CATEGORY_PATH_QUERY = """
-            WITH RECURSIVE category_path AS (
-                SELECT c.*, 0 as path_level 
-                FROM categories c 
-                WHERE c.id = :leafCategoryId 
-                  AND c.deleted_at IS NULL
-                
-                UNION ALL
-                
-                SELECT c.*, cp.path_level + 1 
-                FROM categories c 
-                INNER JOIN category_path cp ON c.id = cp.parent_id
-                WHERE c.deleted_at IS NULL
-            )
-            SELECT * FROM category_path 
-            ORDER BY path_level DESC
-            """;
+    private final JPAQueryFactory queryFactory;
     
     @Override
-    @SuppressWarnings("unchecked")
-    public List<CategoryJpaEntity> findCategoryPath(String leafCategoryId) {
-        Query nativeQuery = entityManager.createNativeQuery(
-            FIND_CATEGORY_PATH_QUERY, 
-            CategoryJpaEntity.class
-        );
-        nativeQuery.setParameter("leafCategoryId", leafCategoryId);
+    public Optional<CategoryJpaEntity> findByIdWithChildrenQueryDsl(String id) {
+        QCategoryJpaEntity category = QCategoryJpaEntity.categoryJpaEntity;
+        QCategoryJpaEntity children = new QCategoryJpaEntity("children");
         
-        return nativeQuery.getResultList();
+        CategoryJpaEntity result = queryFactory
+                .selectFrom(category)
+                .leftJoin(category.children, children).fetchJoin()
+                .where(category.id.eq(id)
+                        .and(category.deletedAt.isNull()))
+                .fetchOne();
+                
+        return Optional.ofNullable(result);
+    }
+    
+    @Override
+    public boolean hasActiveProductsQueryDsl(String categoryId) {
+        QProductCategoryJpaEntity productCategory = QProductCategoryJpaEntity.productCategoryJpaEntity;
+        QProductJpaEntity product = QProductJpaEntity.productJpaEntity;
+        QCategoryJpaEntity category = QCategoryJpaEntity.categoryJpaEntity;
+        
+        Long count = queryFactory
+                .select(productCategory.count())
+                .from(productCategory)
+                .join(productCategory.product, product)
+                .where(productCategory.categoryId.eq(categoryId)
+                        .and(product.status.eq(ProductStatus.ACTIVE))
+                        .and(product.deletedAt.isNull()))
+                .fetchOne();
+                
+        return count != null && count > 0;
+    }
+    
+    @Override
+    public List<CategoryJpaEntity> findAllWithHierarchyQueryDsl() {
+        QCategoryJpaEntity category = QCategoryJpaEntity.categoryJpaEntity;
+        QCategoryJpaEntity children = new QCategoryJpaEntity("children");
+        
+        return queryFactory
+                .selectDistinct(category)
+                .from(category)
+                .leftJoin(category.children, children).fetchJoin()
+                .where(category.parentId.isNull()
+                        .and(category.deletedAt.isNull()))
+                .orderBy(category.sortOrder.asc(), category.name.asc())
+                .fetch();
+    }
+    
+    @Override
+    public List<CategoryJpaEntity> findCategoryPath(String leafCategoryId) {
+        List<CategoryJpaEntity> path = new ArrayList<>();
+        CategoryJpaEntity current = queryFactory
+                .selectFrom(QCategoryJpaEntity.categoryJpaEntity)
+                .where(QCategoryJpaEntity.categoryJpaEntity.id.eq(leafCategoryId)
+                        .and(QCategoryJpaEntity.categoryJpaEntity.deletedAt.isNull()))
+                .fetchOne();
+                
+        while (current != null) {
+            path.add(0, current); // 리스트의 맨 앞에 추가하여 루트->리프 순서로 만듦
+            if (current.getParentId() != null) {
+                current = queryFactory
+                        .selectFrom(QCategoryJpaEntity.categoryJpaEntity)
+                        .where(QCategoryJpaEntity.categoryJpaEntity.id.eq(current.getParentId())
+                                .and(QCategoryJpaEntity.categoryJpaEntity.deletedAt.isNull()))
+                        .fetchOne();
+            } else {
+                current = null;
+            }
+        }
+        
+        return path;
     }
 }

--- a/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/repository/CategoryJpaRepositoryImpl.java
+++ b/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/repository/CategoryJpaRepositoryImpl.java
@@ -91,4 +91,51 @@ public class CategoryJpaRepositoryImpl implements CategoryJpaRepositoryCustom {
         
         return path;
     }
+    
+    @Override
+    public List<CategoryJpaEntity> findRootCategoriesQueryDsl() {
+        QCategoryJpaEntity category = QCategoryJpaEntity.categoryJpaEntity;
+        
+        return queryFactory
+                .selectFrom(category)
+                .where(category.parentId.isNull()
+                        .and(category.deletedAt.isNull()))
+                .orderBy(category.sortOrder.asc(), category.name.asc())
+                .fetch();
+    }
+    
+    @Override
+    public List<CategoryJpaEntity> findByParentIdQueryDsl(String parentId) {
+        QCategoryJpaEntity category = QCategoryJpaEntity.categoryJpaEntity;
+        
+        return queryFactory
+                .selectFrom(category)
+                .where(category.parentId.eq(parentId)
+                        .and(category.deletedAt.isNull()))
+                .orderBy(category.sortOrder.asc(), category.name.asc())
+                .fetch();
+    }
+    
+    @Override
+    public List<CategoryJpaEntity> findActiveCategoriesQueryDsl() {
+        QCategoryJpaEntity category = QCategoryJpaEntity.categoryJpaEntity;
+        
+        return queryFactory
+                .selectFrom(category)
+                .where(category.isActive.eq(true)
+                        .and(category.deletedAt.isNull()))
+                .orderBy(category.level.asc(), category.sortOrder.asc(), category.name.asc())
+                .fetch();
+    }
+    
+    @Override
+    public List<CategoryJpaEntity> findAllByIdInQueryDsl(List<String> categoryIds) {
+        QCategoryJpaEntity category = QCategoryJpaEntity.categoryJpaEntity;
+        
+        return queryFactory
+                .selectFrom(category)
+                .where(category.id.in(categoryIds)
+                        .and(category.deletedAt.isNull()))
+                .fetch();
+    }
 }

--- a/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/repository/CategoryPathQueryExecutor.java
+++ b/infrastructure/product-persistence/src/main/java/com/commerce/product/infrastructure/persistence/repository/CategoryPathQueryExecutor.java
@@ -1,0 +1,56 @@
+package com.commerce.product.infrastructure.persistence.repository;
+
+import com.commerce.product.infrastructure.persistence.entity.CategoryJpaEntity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * 카테고리 경로 조회를 위한 전용 쿼리 실행자
+ * 재귀 CTE와 같은 복잡한 네이티브 쿼리를 별도로 관리합니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class CategoryPathQueryExecutor {
+    
+    private final EntityManager entityManager;
+    
+    // 재귀 CTE 쿼리를 상수로 정의하여 가독성을 높입니다
+    private static final String CATEGORY_PATH_QUERY = """
+            WITH RECURSIVE category_path AS (
+                -- 리프 카테고리에서 시작
+                SELECT c.* 
+                FROM categories c 
+                WHERE c.id = :leafCategoryId 
+                  AND c.deleted_at IS NULL
+                
+                UNION ALL
+                
+                -- 재귀적으로 부모 카테고리를 조회
+                SELECT c.* 
+                FROM categories c 
+                INNER JOIN category_path cp ON c.id = cp.parent_id
+                WHERE c.deleted_at IS NULL
+            )
+            -- 루트부터 리프까지의 순서로 정렬
+            SELECT * FROM category_path 
+            ORDER BY level DESC
+            """;
+    
+    /**
+     * 리프 카테고리부터 루트까지의 경로를 조회합니다.
+     * 
+     * @param leafCategoryId 리프 카테고리 ID
+     * @return 루트부터 리프까지의 카테고리 경로
+     */
+    @SuppressWarnings("unchecked")
+    public List<CategoryJpaEntity> findCategoryPath(String leafCategoryId) {
+        Query query = entityManager.createNativeQuery(CATEGORY_PATH_QUERY, CategoryJpaEntity.class);
+        query.setParameter("leafCategoryId", leafCategoryId);
+        
+        return query.getResultList();
+    }
+}

--- a/infrastructure/product-persistence/src/test/java/com/commerce/product/infrastructure/persistence/adapter/CategoryRepositoryAdapterTest.java
+++ b/infrastructure/product-persistence/src/test/java/com/commerce/product/infrastructure/persistence/adapter/CategoryRepositoryAdapterTest.java
@@ -1,0 +1,415 @@
+package com.commerce.product.infrastructure.persistence.adapter;
+
+import com.commerce.product.domain.model.Category;
+import com.commerce.product.domain.model.CategoryId;
+import com.commerce.product.domain.model.CategoryName;
+import com.commerce.product.infrastructure.persistence.entity.CategoryJpaEntity;
+import com.commerce.product.infrastructure.persistence.repository.CategoryJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryRepositoryAdapterTest {
+    
+    @Mock
+    private CategoryJpaRepository categoryJpaRepository;
+    
+    @InjectMocks
+    private CategoryRepositoryAdapter categoryRepositoryAdapter;
+    
+    private CategoryId categoryId;
+    private CategoryName categoryName;
+    private Category category;
+    private CategoryJpaEntity categoryEntity;
+    
+    @BeforeEach
+    void setUp() {
+        categoryId = new CategoryId(UUID.randomUUID().toString());
+        categoryName = new CategoryName("전자제품");
+        category = Category.createRoot(categoryId, categoryName, 1);
+        
+        categoryEntity = CategoryJpaEntity.builder()
+                .id(categoryId.value())
+                .name(categoryName.value())
+                .parentId(null)
+                .level(1)
+                .sortOrder(1)
+                .isActive(true)
+                .version(0L)
+                .build();
+    }
+    
+    @Test
+    void save_루트카테고리_성공() {
+        // given
+        when(categoryJpaRepository.save(any(CategoryJpaEntity.class)))
+                .thenReturn(categoryEntity);
+        
+        // when
+        Category savedCategory = categoryRepositoryAdapter.save(category);
+        
+        // then
+        assertThat(savedCategory.getId()).isEqualTo(categoryId);
+        assertThat(savedCategory.getName()).isEqualTo(categoryName);
+        assertThat(savedCategory.getLevel()).isEqualTo(1);
+        
+        verify(categoryJpaRepository, times(1)).save(any(CategoryJpaEntity.class));
+    }
+    
+    @Test
+    void save_자식카테고리포함_성공() {
+        // given
+        CategoryId childId = new CategoryId(UUID.randomUUID().toString());
+        CategoryName childName = new CategoryName("스마트폰");
+        Category childCategory = Category.createChild(childId, childName, categoryId, 2, 1);
+        category.addChild(childCategory);
+        
+        CategoryJpaEntity childEntity = CategoryJpaEntity.builder()
+                .id(childId.value())
+                .name(childName.value())
+                .parentId(categoryId.value())
+                .level(2)
+                .sortOrder(1)
+                .isActive(true)
+                .version(0L)
+                .build();
+        
+        when(categoryJpaRepository.save(any(CategoryJpaEntity.class)))
+                .thenReturn(categoryEntity)
+                .thenReturn(childEntity);
+        
+        // when
+        Category savedCategory = categoryRepositoryAdapter.save(category);
+        
+        // then
+        assertThat(savedCategory.getId()).isEqualTo(categoryId);
+        verify(categoryJpaRepository, times(2)).save(any(CategoryJpaEntity.class));
+    }
+    
+    @Test
+    void findById_존재하는경우_성공() {
+        // given
+        when(categoryJpaRepository.findByIdWithChildren(categoryId.value()))
+                .thenReturn(Optional.of(categoryEntity));
+        
+        // when
+        Optional<Category> found = categoryRepositoryAdapter.findById(categoryId);
+        
+        // then
+        assertThat(found).isPresent();
+        assertThat(found.get().getId()).isEqualTo(categoryId);
+        assertThat(found.get().getName()).isEqualTo(categoryName);
+    }
+    
+    @Test
+    void findById_존재하지않는경우_빈Optional반환() {
+        // given
+        when(categoryJpaRepository.findByIdWithChildren(anyString()))
+                .thenReturn(Optional.empty());
+        
+        // when
+        Optional<Category> found = categoryRepositoryAdapter.findById(categoryId);
+        
+        // then
+        assertThat(found).isEmpty();
+    }
+    
+    @Test
+    void findRootCategories_성공() {
+        // given
+        CategoryJpaEntity rootEntity2 = CategoryJpaEntity.builder()
+                .id(UUID.randomUUID().toString())
+                .name("의류")
+                .parentId(null)
+                .level(1)
+                .sortOrder(2)
+                .isActive(true)
+                .version(0L)
+                .build();
+        
+        when(categoryJpaRepository.findRootCategories())
+                .thenReturn(Arrays.asList(categoryEntity, rootEntity2));
+        
+        // when
+        List<Category> rootCategories = categoryRepositoryAdapter.findRootCategories();
+        
+        // then
+        assertThat(rootCategories).hasSize(2);
+        assertThat(rootCategories.get(0).getName().value()).isEqualTo("전자제품");
+        assertThat(rootCategories.get(1).getName().value()).isEqualTo("의류");
+    }
+    
+    @Test
+    void findByParentId_성공() {
+        // given
+        CategoryId parentId = new CategoryId(UUID.randomUUID().toString());
+        
+        CategoryJpaEntity childEntity1 = CategoryJpaEntity.builder()
+                .id(UUID.randomUUID().toString())
+                .name("스마트폰")
+                .parentId(parentId.value())
+                .level(2)
+                .sortOrder(1)
+                .isActive(true)
+                .version(0L)
+                .build();
+                
+        CategoryJpaEntity childEntity2 = CategoryJpaEntity.builder()
+                .id(UUID.randomUUID().toString())
+                .name("노트북")
+                .parentId(parentId.value())
+                .level(2)
+                .sortOrder(2)
+                .isActive(true)
+                .version(0L)
+                .build();
+        
+        when(categoryJpaRepository.findByParentId(parentId.value()))
+                .thenReturn(Arrays.asList(childEntity1, childEntity2));
+        
+        // when
+        List<Category> children = categoryRepositoryAdapter.findByParentId(parentId);
+        
+        // then
+        assertThat(children).hasSize(2);
+        assertThat(children.get(0).getName().value()).isEqualTo("스마트폰");
+        assertThat(children.get(1).getName().value()).isEqualTo("노트북");
+    }
+    
+    @Test
+    void findActiveCategories_성공() {
+        // given
+        CategoryJpaEntity activeEntity1 = CategoryJpaEntity.builder()
+                .id(UUID.randomUUID().toString())
+                .name("활성카테고리1")
+                .parentId(null)
+                .level(1)
+                .sortOrder(1)
+                .isActive(true)
+                .version(0L)
+                .build();
+                
+        CategoryJpaEntity activeEntity2 = CategoryJpaEntity.builder()
+                .id(UUID.randomUUID().toString())
+                .name("활성카테고리2")
+                .parentId(null)
+                .level(1)
+                .sortOrder(2)
+                .isActive(true)
+                .version(0L)
+                .build();
+        
+        when(categoryJpaRepository.findActiveCategories())
+                .thenReturn(Arrays.asList(activeEntity1, activeEntity2));
+        
+        // when
+        List<Category> activeCategories = categoryRepositoryAdapter.findActiveCategories();
+        
+        // then
+        assertThat(activeCategories).hasSize(2);
+        assertThat(activeCategories).allMatch(Category::isActive);
+    }
+    
+    @Test
+    void findCategoryPath_성공() {
+        // given
+        CategoryId leafId = new CategoryId(UUID.randomUUID().toString());
+        
+        CategoryJpaEntity rootEntity = CategoryJpaEntity.builder()
+                .id(UUID.randomUUID().toString())
+                .name("전자제품")
+                .parentId(null)
+                .level(1)
+                .sortOrder(1)
+                .isActive(true)
+                .version(0L)
+                .build();
+                
+        CategoryJpaEntity middleEntity = CategoryJpaEntity.builder()
+                .id(UUID.randomUUID().toString())
+                .name("모바일기기")
+                .parentId(rootEntity.getId())
+                .level(2)
+                .sortOrder(1)
+                .isActive(true)
+                .version(0L)
+                .build();
+                
+        CategoryJpaEntity leafEntity = CategoryJpaEntity.builder()
+                .id(leafId.value())
+                .name("스마트폰")
+                .parentId(middleEntity.getId())
+                .level(3)
+                .sortOrder(1)
+                .isActive(true)
+                .version(0L)
+                .build();
+        
+        when(categoryJpaRepository.findCategoryPath(leafId.value()))
+                .thenReturn(Arrays.asList(rootEntity, middleEntity, leafEntity));
+        
+        // when
+        List<Category> path = categoryRepositoryAdapter.findCategoryPath(leafId);
+        
+        // then
+        assertThat(path).hasSize(3);
+        assertThat(path.get(0).getName().value()).isEqualTo("전자제품");
+        assertThat(path.get(1).getName().value()).isEqualTo("모바일기기");
+        assertThat(path.get(2).getName().value()).isEqualTo("스마트폰");
+    }
+    
+    @Test
+    void delete_성공() {
+        // given
+        when(categoryJpaRepository.findById(categoryId.value()))
+                .thenReturn(Optional.of(categoryEntity));
+        
+        // when
+        categoryRepositoryAdapter.delete(category);
+        
+        // then
+        verify(categoryJpaRepository).findById(categoryId.value());
+        verify(categoryJpaRepository).save(any(CategoryJpaEntity.class));
+    }
+    
+    @Test
+    void hasActiveProducts_true반환() {
+        // given
+        when(categoryJpaRepository.hasActiveProducts(categoryId.value()))
+                .thenReturn(true);
+        
+        // when
+        boolean hasActiveProducts = categoryRepositoryAdapter.hasActiveProducts(categoryId);
+        
+        // then
+        assertThat(hasActiveProducts).isTrue();
+    }
+    
+    @Test
+    void hasActiveProducts_false반환() {
+        // given
+        when(categoryJpaRepository.hasActiveProducts(categoryId.value()))
+                .thenReturn(false);
+        
+        // when
+        boolean hasActiveProducts = categoryRepositoryAdapter.hasActiveProducts(categoryId);
+        
+        // then
+        assertThat(hasActiveProducts).isFalse();
+    }
+    
+    @Test
+    void findAll_성공() {
+        // given
+        when(categoryJpaRepository.findAllWithHierarchy())
+                .thenReturn(Arrays.asList(categoryEntity));
+        
+        // when
+        List<Category> allCategories = categoryRepositoryAdapter.findAll();
+        
+        // then
+        assertThat(allCategories).hasSize(1);
+        assertThat(allCategories.get(0).getId()).isEqualTo(categoryId);
+    }
+    
+    @Test
+    void findAllById_성공() {
+        // given
+        CategoryId id1 = new CategoryId(UUID.randomUUID().toString());
+        CategoryId id2 = new CategoryId(UUID.randomUUID().toString());
+        List<CategoryId> categoryIds = Arrays.asList(id1, id2);
+        
+        CategoryJpaEntity entity1 = CategoryJpaEntity.builder()
+                .id(id1.value())
+                .name("카테고리1")
+                .parentId(null)
+                .level(1)
+                .sortOrder(1)
+                .isActive(true)
+                .version(0L)
+                .build();
+                
+        CategoryJpaEntity entity2 = CategoryJpaEntity.builder()
+                .id(id2.value())
+                .name("카테고리2")
+                .parentId(null)
+                .level(1)
+                .sortOrder(2)
+                .isActive(true)
+                .version(0L)
+                .build();
+        
+        when(categoryJpaRepository.findAllByIdIn(anyList()))
+                .thenReturn(Arrays.asList(entity1, entity2));
+        
+        // when
+        List<Category> categories = categoryRepositoryAdapter.findAllById(categoryIds);
+        
+        // then
+        assertThat(categories).hasSize(2);
+        assertThat(categories).extracting(c -> c.getId().value())
+                .containsExactlyInAnyOrder(id1.value(), id2.value());
+    }
+    
+    @Test
+    void findAllById_빈리스트시_빈결과반환() {
+        // when
+        List<Category> categories = categoryRepositoryAdapter.findAllById(List.of());
+        
+        // then
+        assertThat(categories).isEmpty();
+        verify(categoryJpaRepository, never()).findAllByIdIn(anyList());
+    }
+    
+    @Test
+    void count_성공() {
+        // given
+        when(categoryJpaRepository.count()).thenReturn(5L);
+        
+        // when
+        long count = categoryRepositoryAdapter.count();
+        
+        // then
+        assertThat(count).isEqualTo(5);
+    }
+    
+    @Test
+    void existsById_true반환() {
+        // given
+        when(categoryJpaRepository.existsById(categoryId.value()))
+                .thenReturn(true);
+        
+        // when
+        boolean exists = categoryRepositoryAdapter.existsById(categoryId);
+        
+        // then
+        assertThat(exists).isTrue();
+    }
+    
+    @Test
+    void existsById_false반환() {
+        // given
+        when(categoryJpaRepository.existsById(categoryId.value()))
+                .thenReturn(false);
+        
+        // when
+        boolean exists = categoryRepositoryAdapter.existsById(categoryId);
+        
+        // then
+        assertThat(exists).isFalse();
+    }
+}

--- a/infrastructure/product-persistence/src/test/java/com/commerce/product/infrastructure/persistence/adapter/InventoryRepositoryAdapterTest.java
+++ b/infrastructure/product-persistence/src/test/java/com/commerce/product/infrastructure/persistence/adapter/InventoryRepositoryAdapterTest.java
@@ -1,0 +1,347 @@
+package com.commerce.product.infrastructure.persistence.adapter;
+
+import com.commerce.common.domain.model.Quantity;
+import com.commerce.product.domain.model.inventory.Inventory;
+import com.commerce.product.domain.model.inventory.SkuId;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.*;
+
+class InventoryRepositoryAdapterTest {
+    
+    private MockWebServer mockWebServer;
+    private InventoryRepositoryAdapter adapter;
+    private ObjectMapper objectMapper;
+    
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+        
+        String baseUrl = mockWebServer.url("/").toString();
+        WebClient webClient = WebClient.builder()
+                .baseUrl(baseUrl)
+                .build();
+                
+        adapter = new InventoryRepositoryAdapter(webClient);
+        objectMapper = new ObjectMapper();
+    }
+    
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+    
+    @Test
+    void getAvailableQuantity_성공() throws Exception {
+        // given
+        String skuId = "SKU001";
+        Map<String, Object> responseBody = Map.of(
+                "skuId", skuId,
+                "totalQuantity", 100,
+                "reservedQuantity", 20,
+                "availableQuantity", 80
+        );
+        
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .setBody(objectMapper.writeValueAsString(responseBody)));
+        
+        // when
+        int availableQuantity = adapter.getAvailableQuantity(skuId);
+        
+        // then
+        assertThat(availableQuantity).isEqualTo(80);
+        
+        RecordedRequest request = mockWebServer.takeRequest(1, TimeUnit.SECONDS);
+        assertThat(request).isNotNull();
+        assertThat(request.getMethod()).isEqualTo("GET");
+        assertThat(request.getPath()).isEqualTo("/api/inventory/" + skuId);
+    }
+    
+    @Test
+    void getAvailableQuantity_NotFound시_0반환() throws Exception {
+        // given
+        String skuId = "SKU001";
+        
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(404));
+        
+        // when
+        int availableQuantity = adapter.getAvailableQuantity(skuId);
+        
+        // then
+        assertThat(availableQuantity).isEqualTo(0);
+    }
+    
+    @Test
+    void getAvailableQuantity_서버오류시_0반환() throws Exception {
+        // given
+        String skuId = "SKU001";
+        
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(500));
+        
+        // when
+        int availableQuantity = adapter.getAvailableQuantity(skuId);
+        
+        // then
+        assertThat(availableQuantity).isEqualTo(0);
+    }
+    
+    @Test
+    void reserveStock_성공() throws Exception {
+        // given
+        String skuId = "SKU001";
+        int quantity = 5;
+        String orderId = "ORDER001";
+        String expectedReservationId = "RESERVATION001";
+        
+        Map<String, Object> responseBody = Map.of(
+                "reservationId", expectedReservationId,
+                "skuId", skuId,
+                "quantity", quantity,
+                "orderId", orderId,
+                "expiresAt", "2024-01-01T10:00:00Z"
+        );
+        
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .setBody(objectMapper.writeValueAsString(responseBody)));
+        
+        // when
+        String reservationId = adapter.reserveStock(skuId, quantity, orderId);
+        
+        // then
+        assertThat(reservationId).isEqualTo(expectedReservationId);
+        
+        RecordedRequest request = mockWebServer.takeRequest(1, TimeUnit.SECONDS);
+        assertThat(request).isNotNull();
+        assertThat(request.getMethod()).isEqualTo("POST");
+        assertThat(request.getPath()).isEqualTo("/api/inventory/reservations");
+        
+        String requestBody = request.getBody().readUtf8();
+        assertThat(requestBody).contains("\"skuId\":\"" + skuId + "\"");
+        assertThat(requestBody).contains("\"quantity\":" + quantity);
+        assertThat(requestBody).contains("\"orderId\":\"" + orderId + "\"");
+        assertThat(requestBody).contains("\"ttl\":300");
+    }
+    
+    @Test
+    void reserveStock_실패시_예외발생() {
+        // given
+        String skuId = "SKU001";
+        int quantity = 5;
+        String orderId = "ORDER001";
+        
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(500));
+        
+        // when & then
+        assertThatThrownBy(() -> adapter.reserveStock(skuId, quantity, orderId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("재고 예약 중 오류가 발생했습니다.");
+    }
+    
+    @Test
+    void releaseReservation_성공() throws Exception {
+        // given
+        String reservationId = "RESERVATION001";
+        
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(204));
+        
+        // when & then
+        assertThatNoException().isThrownBy(() -> adapter.releaseReservation(reservationId));
+        
+        RecordedRequest request = mockWebServer.takeRequest(1, TimeUnit.SECONDS);
+        assertThat(request).isNotNull();
+        assertThat(request.getMethod()).isEqualTo("DELETE");
+        assertThat(request.getPath()).isEqualTo("/api/inventory/reservations/" + reservationId);
+    }
+    
+    @Test
+    void releaseReservation_실패시_예외발생하지않음() {
+        // given
+        String reservationId = "RESERVATION001";
+        
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(500));
+        
+        // when & then
+        assertThatNoException().isThrownBy(() -> adapter.releaseReservation(reservationId));
+    }
+    
+    @Test
+    void findBySkuId_성공() throws Exception {
+        // given
+        SkuId skuId = new SkuId("SKU001");
+        Map<String, Object> responseBody = Map.of(
+                "skuId", skuId.value(),
+                "totalQuantity", 100,
+                "reservedQuantity", 20,
+                "availableQuantity", 80
+        );
+        
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .setBody(objectMapper.writeValueAsString(responseBody)));
+        
+        // when
+        Optional<Inventory> result = adapter.findBySkuId(skuId);
+        
+        // then
+        assertThat(result).isPresent();
+        Inventory inventory = result.get();
+        assertThat(inventory.getAvailableQuantity()).isEqualTo(Quantity.of(80));
+    }
+    
+    @Test
+    void findBySkuId_NotFound시_빈Optional반환() throws Exception {
+        // given
+        SkuId skuId = new SkuId("SKU001");
+        
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(404));
+        
+        // when
+        Optional<Inventory> result = adapter.findBySkuId(skuId);
+        
+        // then
+        assertThat(result).isEmpty();
+    }
+    
+    @Test
+    void save_호출시_예외발생() {
+        // given
+        Inventory inventory = new TestInventory();
+        
+        // when & then
+        assertThatThrownBy(() -> adapter.save(inventory))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Product service cannot directly save inventory");
+    }
+    
+    private static class TestInventory implements Inventory {
+        @Override
+        public Quantity getAvailableQuantity() {
+            return Quantity.of(100);
+        }
+    }
+    
+    @Test
+    void findBySkuIds_성공() throws Exception {
+        // given
+        List<SkuId> skuIds = Arrays.asList(
+                new SkuId("SKU001"),
+                new SkuId("SKU002")
+        );
+        
+        Map<String, Object> response1 = Map.of(
+                "skuId", "SKU001",
+                "totalQuantity", 100,
+                "reservedQuantity", 20,
+                "availableQuantity", 80
+        );
+        
+        Map<String, Object> response2 = Map.of(
+                "skuId", "SKU002",
+                "totalQuantity", 50,
+                "reservedQuantity", 10,
+                "availableQuantity", 40
+        );
+        
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .setBody(objectMapper.writeValueAsString(response1)));
+                
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .setBody(objectMapper.writeValueAsString(response2)));
+        
+        // when
+        Map<SkuId, Inventory> result = adapter.findBySkuIds(skuIds);
+        
+        // then
+        assertThat(result).hasSize(2);
+        
+        Inventory inventory1 = result.get(new SkuId("SKU001"));
+        assertThat(inventory1).isNotNull();
+        assertThat(inventory1.getAvailableQuantity()).isEqualTo(Quantity.of(80));
+        
+        Inventory inventory2 = result.get(new SkuId("SKU002"));
+        assertThat(inventory2).isNotNull();
+        assertThat(inventory2.getAvailableQuantity()).isEqualTo(Quantity.of(40));
+    }
+    
+    @Test
+    void findBySkuIds_빈리스트시_빈맵반환() {
+        // when
+        Map<SkuId, Inventory> result = adapter.findBySkuIds(List.of());
+        
+        // then
+        assertThat(result).isEmpty();
+    }
+    
+    @Test
+    void findBySkuIds_null리스트시_빈맵반환() {
+        // when
+        Map<SkuId, Inventory> result = adapter.findBySkuIds(null);
+        
+        // then
+        assertThat(result).isEmpty();
+    }
+    
+    @Test
+    void findBySkuIds_일부실패시_성공한것만반환() throws Exception {
+        // given
+        List<SkuId> skuIds = Arrays.asList(
+                new SkuId("SKU001"),
+                new SkuId("SKU002")
+        );
+        
+        Map<String, Object> response1 = Map.of(
+                "skuId", "SKU001",
+                "totalQuantity", 100,
+                "reservedQuantity", 20,
+                "availableQuantity", 80
+        );
+        
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .setBody(objectMapper.writeValueAsString(response1)));
+                
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(500)); // SKU002는 서버 오류
+        
+        // when
+        Map<SkuId, Inventory> result = adapter.findBySkuIds(skuIds);
+        
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result).containsKey(new SkuId("SKU001"));
+        assertThat(result).doesNotContainKey(new SkuId("SKU002"));
+    }
+}


### PR DESCRIPTION
## 작업 내용

IMPLEMENTATION_PLAN.md에서 정의한 7.2 Repository Adapter 작업을 완료했습니다.

### 구현 사항

#### 1. InventoryRepositoryAdapter
- Product 도메인에서 Inventory 서비스와 통신하기 위한 어댑터 구현
- WebClient를 사용하여 REST API 호출
- 재고 조회, 예약, 해제 기능 구현
- MockWebServer를 활용한 단위 테스트 작성

#### 2. CategoryRepositoryAdapter  
- Category 도메인 리포지토리의 JPA 구현체
- 카테고리 계층 구조 지원 (최대 3단계)
- 소프트 삭제(soft delete) 기능 구현
- Mockito를 활용한 단위 테스트 작성

#### 3. 추가 구성
- WebClientConfig: Inventory 서비스 통신을 위한 WebClient 설정
- CategoryJpaRepository: 카테고리 관련 JPA 쿼리 메서드 정의
- build.gradle: product-persistence 모듈 의존성 설정

### 테스트 결과
- 모든 테스트 통과
- TDD 방식으로 테스트 우선 작성 후 구현

### 관련 이슈
Closes #66

### 체크리스트
- [x] 코드 작성
- [x] 테스트 작성 및 통과
- [x] IMPLEMENTATION_PLAN.md 업데이트
- [x] 커밋 메시지 규칙 준수