### PR TITLE
feat(#67): Persistence Adapter - Mapper 구현

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -135,8 +135,8 @@ JPA 기반 영속성 계층
 - [x] CategoryRepositoryAdapter
 
 #### 7.3 Mapper 구현
-- [ ] Domain ↔ JPA Entity 매핑
-- [ ] 복잡한 관계 매핑 처리
+- [x] Domain ↔ JPA Entity 매핑
+- [x] 복잡한 관계 매핑 처리
 
 ### 8. Event Adapter 구현 ⭐⭐⭐
 Kafka 기반 이벤트 처리

--- a/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/ReservationPersistenceAdapter.java
+++ b/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/adapter/ReservationPersistenceAdapter.java
@@ -1,9 +1,9 @@
 package com.commerce.inventory.infrastructure.persistence.adapter;
 
-import com.commerce.common.domain.model.Quantity;
 import com.commerce.inventory.application.service.port.out.LoadReservationPort;
 import com.commerce.inventory.application.service.port.out.SaveReservationPort;
-import com.commerce.inventory.domain.model.*;
+import com.commerce.inventory.domain.model.Reservation;
+import com.commerce.inventory.domain.model.ReservationId;
 import com.commerce.inventory.infrastructure.persistence.entity.ReservationJpaEntity;
 import com.commerce.inventory.infrastructure.persistence.repository.ReservationJpaRepository;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +24,7 @@ public class ReservationPersistenceAdapter implements LoadReservationPort, SaveR
     @Override
     public Optional<Reservation> findById(ReservationId id) {
         return reservationJpaRepository.findById(id.value())
-                .map(this::toDomainEntity);
+                .map(ReservationJpaEntity::toDomainModel);
     }
     
     @Override
@@ -34,74 +34,28 @@ public class ReservationPersistenceAdapter implements LoadReservationPort, SaveR
                 .collect(Collectors.toList());
         
         return reservationJpaRepository.findAllByIdIn(idValues).stream()
-                .map(this::toDomainEntity)
+                .map(ReservationJpaEntity::toDomainModel)
                 .collect(Collectors.toList());
     }
     
     @Override
     public Optional<Reservation> findByOrderIdAndInventoryId(String orderId, String inventoryId) {
         return reservationJpaRepository.findByOrderIdAndInventoryId(orderId, inventoryId)
-                .map(this::toDomainEntity);
+                .map(ReservationJpaEntity::toDomainModel);
     }
     
     @Override
     public List<Reservation> findByOrderId(String orderId) {
         return reservationJpaRepository.findByOrderId(orderId).stream()
-                .map(this::toDomainEntity)
+                .map(ReservationJpaEntity::toDomainModel)
                 .collect(Collectors.toList());
     }
     
     @Override
     @Transactional
     public Reservation save(Reservation reservation) {
-        ReservationJpaEntity jpaEntity = toJpaEntity(reservation);
+        ReservationJpaEntity jpaEntity = ReservationJpaEntity.fromDomainModel(reservation);
         ReservationJpaEntity savedEntity = reservationJpaRepository.save(jpaEntity);
-        return toDomainEntity(savedEntity);
-    }
-    
-    private Reservation toDomainEntity(ReservationJpaEntity jpaEntity) {
-        return Reservation.restore(
-                new ReservationId(jpaEntity.getId()),
-                new SkuId(jpaEntity.getSkuId()),
-                Quantity.of(jpaEntity.getQuantity()),
-                jpaEntity.getOrderId(),
-                jpaEntity.getExpiresAt(),
-                mapToDomainStatus(jpaEntity.getStatus()),
-                jpaEntity.getCreatedAt(),
-                jpaEntity.getVersion()
-        );
-    }
-    
-    private ReservationJpaEntity toJpaEntity(Reservation domainEntity) {
-        return ReservationJpaEntity.builder()
-                .id(domainEntity.getId().value())
-                .skuId(domainEntity.getSkuId().value())
-                .inventoryId(domainEntity.getSkuId().value()) // SKU ID를 inventory ID로 사용
-                .quantity(domainEntity.getQuantity().value())
-                .orderId(domainEntity.getOrderId())
-                .expiresAt(domainEntity.getExpiresAt())
-                .status(mapToJpaStatus(domainEntity.getStatus()))
-                .createdAt(domainEntity.getCreatedAt())
-                .updatedAt(domainEntity.getUpdatedAt())
-                .version(domainEntity.getVersion())
-                .build();
-    }
-    
-    private ReservationStatus mapToDomainStatus(ReservationJpaEntity.ReservationStatus jpaStatus) {
-        return switch (jpaStatus) {
-            case ACTIVE -> ReservationStatus.ACTIVE;
-            case CONFIRMED -> ReservationStatus.CONFIRMED;
-            case RELEASED -> ReservationStatus.RELEASED;
-            case EXPIRED -> ReservationStatus.EXPIRED;
-        };
-    }
-    
-    private ReservationJpaEntity.ReservationStatus mapToJpaStatus(ReservationStatus domainStatus) {
-        return switch (domainStatus) {
-            case ACTIVE -> ReservationJpaEntity.ReservationStatus.ACTIVE;
-            case CONFIRMED -> ReservationJpaEntity.ReservationStatus.CONFIRMED;
-            case RELEASED -> ReservationJpaEntity.ReservationStatus.RELEASED;
-            case EXPIRED -> ReservationJpaEntity.ReservationStatus.EXPIRED;
-        };
+        return savedEntity.toDomainModel();
     }
 }

--- a/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/entity/InventoryJpaEntity.java
+++ b/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/entity/InventoryJpaEntity.java
@@ -1,5 +1,8 @@
 package com.commerce.inventory.infrastructure.persistence.entity;
 
+import com.commerce.common.domain.model.Quantity;
+import com.commerce.inventory.domain.model.Inventory;
+import com.commerce.inventory.domain.model.SkuId;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -32,4 +35,26 @@ public class InventoryJpaEntity {
     
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+    
+    public static InventoryJpaEntity fromDomainModel(Inventory inventory) {
+        return InventoryJpaEntity.builder()
+                .skuId(inventory.getSkuId().value())
+                .totalQuantity(inventory.getTotalQuantity().value())
+                .reservedQuantity(inventory.getReservedQuantity().value())
+                .version(inventory.getVersion())
+                .createdAt(inventory.getCreatedAt())
+                .updatedAt(inventory.getUpdatedAt())
+                .build();
+    }
+    
+    public Inventory toDomainModel() {
+        return Inventory.restore(
+                SkuId.of(skuId),
+                Quantity.of(totalQuantity),
+                Quantity.of(reservedQuantity),
+                version,
+                createdAt,
+                updatedAt
+        );
+    }
 }

--- a/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/entity/ReservationJpaEntity.java
+++ b/infrastructure/inventory-persistence/src/main/java/com/commerce/inventory/infrastructure/persistence/entity/ReservationJpaEntity.java
@@ -1,5 +1,10 @@
 package com.commerce.inventory.infrastructure.persistence.entity;
 
+import com.commerce.common.domain.model.Quantity;
+import com.commerce.inventory.domain.model.Reservation;
+import com.commerce.inventory.domain.model.ReservationId;
+import com.commerce.inventory.domain.model.ReservationStatus;
+import com.commerce.inventory.domain.model.SkuId;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -60,5 +65,51 @@ public class ReservationJpaEntity {
         CONFIRMED,
         RELEASED,
         EXPIRED
+    }
+    
+    public static ReservationJpaEntity fromDomainModel(Reservation reservation) {
+        return ReservationJpaEntity.builder()
+                .id(reservation.getId().value())
+                .skuId(reservation.getSkuId().value())
+                .inventoryId(reservation.getSkuId().value()) // SKU ID를 inventory ID로 사용
+                .quantity(reservation.getQuantity().value())
+                .orderId(reservation.getOrderId())
+                .expiresAt(reservation.getExpiresAt())
+                .status(mapToJpaStatus(reservation.getStatus()))
+                .createdAt(reservation.getCreatedAt())
+                .updatedAt(reservation.getUpdatedAt())
+                .version(reservation.getVersion())
+                .build();
+    }
+    
+    public Reservation toDomainModel() {
+        return Reservation.restore(
+                new ReservationId(id),
+                new SkuId(skuId),
+                Quantity.of(quantity),
+                orderId,
+                expiresAt,
+                mapToDomainStatus(status),
+                createdAt,
+                version
+        );
+    }
+    
+    private static ReservationStatus mapToJpaStatus(com.commerce.inventory.domain.model.ReservationStatus domainStatus) {
+        return switch (domainStatus) {
+            case ACTIVE -> ReservationStatus.ACTIVE;
+            case CONFIRMED -> ReservationStatus.CONFIRMED;
+            case RELEASED -> ReservationStatus.RELEASED;
+            case EXPIRED -> ReservationStatus.EXPIRED;
+        };
+    }
+    
+    private static com.commerce.inventory.domain.model.ReservationStatus mapToDomainStatus(ReservationStatus jpaStatus) {
+        return switch (jpaStatus) {
+            case ACTIVE -> com.commerce.inventory.domain.model.ReservationStatus.ACTIVE;
+            case CONFIRMED -> com.commerce.inventory.domain.model.ReservationStatus.CONFIRMED;
+            case RELEASED -> com.commerce.inventory.domain.model.ReservationStatus.RELEASED;
+            case EXPIRED -> com.commerce.inventory.domain.model.ReservationStatus.EXPIRED;
+        };
     }
 }

--- a/infrastructure/inventory-persistence/src/test/java/com/commerce/inventory/infrastructure/persistence/entity/InventoryJpaEntityTest.java
+++ b/infrastructure/inventory-persistence/src/test/java/com/commerce/inventory/infrastructure/persistence/entity/InventoryJpaEntityTest.java
@@ -1,0 +1,134 @@
+package com.commerce.inventory.infrastructure.persistence.entity;
+
+import com.commerce.common.domain.model.Quantity;
+import com.commerce.inventory.domain.model.Inventory;
+import com.commerce.inventory.domain.model.SkuId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InventoryJpaEntityTest {
+
+    @Test
+    @DisplayName("도메인 모델을 JPA 엔티티로 변환할 수 있다")
+    void should_convert_from_domain_model() {
+        // given
+        SkuId skuId = SkuId.of("SKU-123");
+        Quantity totalQuantity = Quantity.of(100);
+        Quantity reservedQuantity = Quantity.of(20);
+        Long version = 1L;
+        LocalDateTime createdAt = LocalDateTime.now();
+        LocalDateTime updatedAt = LocalDateTime.now();
+        
+        Inventory inventory = Inventory.restore(
+                skuId,
+                totalQuantity,
+                reservedQuantity,
+                version,
+                createdAt,
+                updatedAt
+        );
+
+        // when
+        InventoryJpaEntity entity = InventoryJpaEntity.fromDomainModel(inventory);
+
+        // then
+        assertThat(entity.getSkuId()).isEqualTo(skuId.value());
+        assertThat(entity.getTotalQuantity()).isEqualTo(totalQuantity.value());
+        assertThat(entity.getReservedQuantity()).isEqualTo(reservedQuantity.value());
+        assertThat(entity.getVersion()).isEqualTo(version);
+        assertThat(entity.getCreatedAt()).isEqualTo(createdAt);
+        assertThat(entity.getUpdatedAt()).isEqualTo(updatedAt);
+    }
+
+    @Test
+    @DisplayName("JPA 엔티티를 도메인 모델로 변환할 수 있다")
+    void should_convert_to_domain_model() {
+        // given
+        String skuId = "SKU-123";
+        Integer totalQuantity = 100;
+        Integer reservedQuantity = 20;
+        Long version = 1L;
+        LocalDateTime createdAt = LocalDateTime.now();
+        LocalDateTime updatedAt = LocalDateTime.now();
+        
+        InventoryJpaEntity entity = InventoryJpaEntity.builder()
+                .skuId(skuId)
+                .totalQuantity(totalQuantity)
+                .reservedQuantity(reservedQuantity)
+                .version(version)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .build();
+
+        // when
+        Inventory inventory = entity.toDomainModel();
+
+        // then
+        assertThat(inventory.getSkuId()).isEqualTo(SkuId.of(skuId));
+        assertThat(inventory.getTotalQuantity()).isEqualTo(Quantity.of(totalQuantity));
+        assertThat(inventory.getReservedQuantity()).isEqualTo(Quantity.of(reservedQuantity));
+        assertThat(inventory.getVersion()).isEqualTo(version);
+        assertThat(inventory.getCreatedAt()).isEqualTo(createdAt);
+        assertThat(inventory.getUpdatedAt()).isEqualTo(updatedAt);
+    }
+
+    @Test
+    @DisplayName("신규 재고 생성시 도메인 모델을 JPA 엔티티로 변환할 수 있다")
+    void should_convert_new_inventory_from_domain_model() {
+        // given
+        SkuId skuId = SkuId.of("SKU-456");
+        Inventory inventory = Inventory.createEmpty(skuId);
+
+        // when
+        InventoryJpaEntity entity = InventoryJpaEntity.fromDomainModel(inventory);
+
+        // then
+        assertThat(entity.getSkuId()).isEqualTo(skuId.value());
+        assertThat(entity.getTotalQuantity()).isEqualTo(0);
+        assertThat(entity.getReservedQuantity()).isEqualTo(0);
+        assertThat(entity.getVersion()).isEqualTo(0L);
+        assertThat(entity.getCreatedAt()).isNotNull();
+        assertThat(entity.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("재고 수량이 변경된 도메인 모델을 JPA 엔티티로 변환할 수 있다")
+    void should_convert_updated_inventory_from_domain_model() {
+        // given
+        SkuId skuId = SkuId.of("SKU-789");
+        Inventory inventory = Inventory.createWithInitialStock(skuId, Quantity.of(50));
+        inventory.reserve(Quantity.of(10), "ORDER-123", 3600);
+
+        // when
+        InventoryJpaEntity entity = InventoryJpaEntity.fromDomainModel(inventory);
+
+        // then
+        assertThat(entity.getSkuId()).isEqualTo(skuId.value());
+        assertThat(entity.getTotalQuantity()).isEqualTo(50);
+        assertThat(entity.getReservedQuantity()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("가용 재고가 계산된 도메인 모델을 정확히 복원할 수 있다")
+    void should_correctly_restore_domain_model_with_available_quantity() {
+        // given
+        InventoryJpaEntity entity = InventoryJpaEntity.builder()
+                .skuId("SKU-999")
+                .totalQuantity(100)
+                .reservedQuantity(30)
+                .version(2L)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        // when
+        Inventory inventory = entity.toDomainModel();
+
+        // then
+        assertThat(inventory.getAvailableQuantity()).isEqualTo(Quantity.of(70));
+    }
+}

--- a/infrastructure/inventory-persistence/src/test/java/com/commerce/inventory/infrastructure/persistence/entity/ReservationJpaEntityTest.java
+++ b/infrastructure/inventory-persistence/src/test/java/com/commerce/inventory/infrastructure/persistence/entity/ReservationJpaEntityTest.java
@@ -1,0 +1,184 @@
+package com.commerce.inventory.infrastructure.persistence.entity;
+
+import com.commerce.common.domain.model.Quantity;
+import com.commerce.inventory.domain.model.Reservation;
+import com.commerce.inventory.domain.model.ReservationId;
+import com.commerce.inventory.domain.model.ReservationStatus;
+import com.commerce.inventory.domain.model.SkuId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReservationJpaEntityTest {
+
+    @Test
+    @DisplayName("도메인 모델을 JPA 엔티티로 변환할 수 있다")
+    void should_convert_from_domain_model() {
+        // given
+        ReservationId id = ReservationId.generate();
+        SkuId skuId = SkuId.of("SKU-123");
+        Quantity quantity = Quantity.of(5);
+        String orderId = "ORDER-123";
+        LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(30);
+        ReservationStatus status = ReservationStatus.ACTIVE;
+        LocalDateTime createdAt = LocalDateTime.now();
+        Long version = 0L;
+        
+        Reservation reservation = Reservation.restore(
+                id,
+                skuId,
+                quantity,
+                orderId,
+                expiresAt,
+                status,
+                createdAt,
+                version
+        );
+
+        // when
+        ReservationJpaEntity entity = ReservationJpaEntity.fromDomainModel(reservation);
+
+        // then
+        assertThat(entity.getId()).isEqualTo(id.value());
+        assertThat(entity.getSkuId()).isEqualTo(skuId.value());
+        assertThat(entity.getInventoryId()).isEqualTo(skuId.value()); // SKU ID를 inventory ID로 사용
+        assertThat(entity.getQuantity()).isEqualTo(quantity.value());
+        assertThat(entity.getOrderId()).isEqualTo(orderId);
+        assertThat(entity.getExpiresAt()).isEqualTo(expiresAt);
+        assertThat(entity.getStatus()).isEqualTo(ReservationJpaEntity.ReservationStatus.ACTIVE);
+        assertThat(entity.getCreatedAt()).isEqualTo(createdAt);
+        assertThat(entity.getUpdatedAt()).isEqualTo(reservation.getUpdatedAt());
+        assertThat(entity.getVersion()).isEqualTo(version);
+    }
+
+    @Test
+    @DisplayName("JPA 엔티티를 도메인 모델로 변환할 수 있다")
+    void should_convert_to_domain_model() {
+        // given
+        String id = "RES-123";
+        String skuId = "SKU-123";
+        Integer quantity = 5;
+        String orderId = "ORDER-123";
+        LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(30);
+        ReservationJpaEntity.ReservationStatus status = ReservationJpaEntity.ReservationStatus.ACTIVE;
+        LocalDateTime createdAt = LocalDateTime.now();
+        LocalDateTime updatedAt = LocalDateTime.now();
+        Long version = 1L;
+        
+        ReservationJpaEntity entity = ReservationJpaEntity.builder()
+                .id(id)
+                .skuId(skuId)
+                .inventoryId(skuId)
+                .quantity(quantity)
+                .orderId(orderId)
+                .expiresAt(expiresAt)
+                .status(status)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .version(version)
+                .build();
+
+        // when
+        Reservation reservation = entity.toDomainModel();
+
+        // then
+        assertThat(reservation.getId()).isEqualTo(new ReservationId(id));
+        assertThat(reservation.getSkuId()).isEqualTo(new SkuId(skuId));
+        assertThat(reservation.getQuantity()).isEqualTo(Quantity.of(quantity));
+        assertThat(reservation.getOrderId()).isEqualTo(orderId);
+        assertThat(reservation.getExpiresAt()).isEqualTo(expiresAt);
+        assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.ACTIVE);
+        assertThat(reservation.getCreatedAt()).isEqualTo(createdAt);
+        assertThat(reservation.getVersion()).isEqualTo(version);
+    }
+
+    @Test
+    @DisplayName("다양한 상태의 예약을 정확히 변환할 수 있다")
+    void should_convert_different_reservation_statuses() {
+        // given
+        testStatusConversion(ReservationStatus.ACTIVE, ReservationJpaEntity.ReservationStatus.ACTIVE);
+        testStatusConversion(ReservationStatus.CONFIRMED, ReservationJpaEntity.ReservationStatus.CONFIRMED);
+        testStatusConversion(ReservationStatus.RELEASED, ReservationJpaEntity.ReservationStatus.RELEASED);
+        testStatusConversion(ReservationStatus.EXPIRED, ReservationJpaEntity.ReservationStatus.EXPIRED);
+    }
+    
+    private void testStatusConversion(ReservationStatus domainStatus, ReservationJpaEntity.ReservationStatus expectedJpaStatus) {
+        // given
+        Reservation reservation = Reservation.restore(
+                ReservationId.generate(),
+                SkuId.of("SKU-123"),
+                Quantity.of(5),
+                "ORDER-123",
+                LocalDateTime.now().plusMinutes(30),
+                domainStatus,
+                LocalDateTime.now(),
+                0L
+        );
+
+        // when
+        ReservationJpaEntity entity = ReservationJpaEntity.fromDomainModel(reservation);
+        
+        // then
+        assertThat(entity.getStatus()).isEqualTo(expectedJpaStatus);
+        
+        // when - reverse conversion
+        Reservation restoredReservation = entity.toDomainModel();
+        
+        // then
+        assertThat(restoredReservation.getStatus()).isEqualTo(domainStatus);
+    }
+
+    @Test
+    @DisplayName("신규 예약 생성시 도메인 모델을 JPA 엔티티로 변환할 수 있다")
+    void should_convert_new_reservation_from_domain_model() {
+        // given
+        SkuId skuId = SkuId.of("SKU-456");
+        Quantity quantity = Quantity.of(10);
+        String orderId = "ORDER-456";
+        int ttlSeconds = 1800; // 30분
+        
+        Reservation reservation = Reservation.create(skuId, quantity, orderId, ttlSeconds);
+
+        // when
+        ReservationJpaEntity entity = ReservationJpaEntity.fromDomainModel(reservation);
+
+        // then
+        assertThat(entity.getId()).isNotNull();
+        assertThat(entity.getSkuId()).isEqualTo(skuId.value());
+        assertThat(entity.getInventoryId()).isEqualTo(skuId.value());
+        assertThat(entity.getQuantity()).isEqualTo(quantity.value());
+        assertThat(entity.getOrderId()).isEqualTo(orderId);
+        assertThat(entity.getExpiresAt()).isAfter(LocalDateTime.now());
+        assertThat(entity.getStatus()).isEqualTo(ReservationJpaEntity.ReservationStatus.ACTIVE);
+        assertThat(entity.getVersion()).isEqualTo(0L);
+    }
+
+    @Test
+    @DisplayName("만료된 예약을 정확히 복원할 수 있다")
+    void should_correctly_restore_expired_reservation() {
+        // given
+        LocalDateTime expiredTime = LocalDateTime.now().minusHours(1);
+        ReservationJpaEntity entity = ReservationJpaEntity.builder()
+                .id("RES-999")
+                .skuId("SKU-999")
+                .inventoryId("SKU-999")
+                .quantity(3)
+                .orderId("ORDER-999")
+                .expiresAt(expiredTime)
+                .status(ReservationJpaEntity.ReservationStatus.EXPIRED)
+                .createdAt(LocalDateTime.now().minusHours(2))
+                .updatedAt(LocalDateTime.now().minusMinutes(30))
+                .version(2L)
+                .build();
+
+        // when
+        Reservation reservation = entity.toDomainModel();
+
+        // then
+        assertThat(reservation.isExpired(LocalDateTime.now())).isTrue();
+        assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.EXPIRED);
+    }
+}


### PR DESCRIPTION
## 개요
Persistence Adapter의 Mapper 구현 작업을 완료했습니다.

## 주요 변경사항

### 1. InventoryJpaEntity Mapper 구현
- `fromDomainModel()`: Inventory 도메인 모델을 JPA 엔티티로 변환
- `toDomainModel()`: JPA 엔티티를 Inventory 도메인 모델로 복원
- 값 객체(SkuId, Quantity) 처리 포함

### 2. ReservationJpaEntity Mapper 구현  
- `fromDomainModel()`: Reservation 도메인 모델을 JPA 엔티티로 변환
- `toDomainModel()`: JPA 엔티티를 Reservation 도메인 모델로 복원
- 상태 enum 매핑 메서드 추가 (도메인 상태 ↔ JPA 상태)

### 3. 코드 품질 개선
- 기존 Adapter의 중복된 private 매핑 메서드 제거
- Entity 클래스에 매핑 로직 통합으로 일관성 확보
- 다른 Entity들과 동일한 패턴 적용

### 4. 테스트 추가
- `InventoryJpaEntityTest`: 양방향 변환 테스트 및 edge case 검증
- `ReservationJpaEntityTest`: 다양한 상태 변환 및 만료 예약 복원 테스트

## 테스트 결과
- 모든 테스트 통과 ✅
- 테스트 커버리지 기준 충족 ✅

Closes #67