### PR TITLE
feat(#68): Event Adapter - Event Publisher 구현

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -142,9 +142,9 @@ JPA 기반 영속성 계층
 Kafka 기반 이벤트 처리
 
 #### 8.1 Event Publisher
-- [ ] KafkaEventPublisher 구현
-- [ ] Event Serialization 처리
-- [ ] Error Handling
+- [x] KafkaEventPublisher 구현
+- [x] Event Serialization 처리
+- [x] Error Handling
 
 #### 8.2 Event Consumer
 - [ ] Event Handler 구현

--- a/infrastructure/inventory-event-kafka/build.gradle
+++ b/infrastructure/inventory-event-kafka/build.gradle
@@ -1,0 +1,39 @@
+plugins {
+    id 'java'
+}
+
+dependencies {
+    implementation project(':common')
+    implementation project(':inventory-core')
+    
+    // Spring Kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'org.springframework.boot:spring-boot-starter'
+    
+    // Jackson for JSON serialization
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    
+    // Apache Kafka clients
+    implementation 'org.apache.kafka:kafka-clients'
+    
+    // Micrometer for metrics
+    implementation 'io.micrometer:micrometer-core'
+    
+    // Configuration
+    implementation 'org.springframework.boot:spring-boot-configuration-processor'
+    
+    // Testing
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+    testImplementation 'org.testcontainers:kafka'
+    testImplementation 'org.testcontainers:junit-jupiter'
+}
+
+test {
+    useJUnitPlatform()
+}
+
+jar {
+    enabled = true
+}

--- a/infrastructure/inventory-event-kafka/src/main/java/com/commerce/inventory/infrastructure/event/config/KafkaProducerConfig.java
+++ b/infrastructure/inventory-event-kafka/src/main/java/com/commerce/inventory/infrastructure/event/config/KafkaProducerConfig.java
@@ -1,0 +1,89 @@
+package com.commerce.inventory.infrastructure.event.config;
+
+import com.commerce.inventory.infrastructure.event.serialization.EventMessage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Kafka Producer 설정
+ */
+@Configuration
+public class KafkaProducerConfig {
+    
+    @Value("${spring.kafka.bootstrap-servers:localhost:9092}")
+    private String bootstrapServers;
+    
+    @Value("${spring.kafka.producer.acks:all}")
+    private String acks;
+    
+    @Value("${spring.kafka.producer.retries:3}")
+    private Integer retries;
+    
+    @Value("${spring.kafka.producer.batch-size:16384}")
+    private Integer batchSize;
+    
+    @Value("${spring.kafka.producer.linger-ms:1}")
+    private Integer lingerMs;
+    
+    @Value("${spring.kafka.producer.buffer-memory:33554432}")
+    private Integer bufferMemory;
+    
+    @Value("${spring.kafka.producer.compression-type:snappy}")
+    private String compressionType;
+    
+    @Value("${spring.kafka.producer.idempotence:true}")
+    private Boolean idempotence;
+    
+    @Bean
+    public ProducerFactory<String, EventMessage> producerFactory() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        configs.put(ProducerConfig.ACKS_CONFIG, acks);
+        configs.put(ProducerConfig.RETRIES_CONFIG, retries);
+        configs.put(ProducerConfig.BATCH_SIZE_CONFIG, batchSize);
+        configs.put(ProducerConfig.LINGER_MS_CONFIG, lingerMs);
+        configs.put(ProducerConfig.BUFFER_MEMORY_CONFIG, bufferMemory);
+        configs.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, compressionType);
+        configs.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, idempotence);
+        
+        // Request timeout 설정
+        configs.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 30000);
+        configs.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 60000);
+        
+        // Idempotent producer를 위한 설정
+        if (idempotence) {
+            configs.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5);
+            configs.put(ProducerConfig.RETRIES_CONFIG, Integer.MAX_VALUE);
+        }
+        
+        return new DefaultKafkaProducerFactory<>(configs);
+    }
+    
+    @Bean
+    public KafkaTemplate<String, EventMessage> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+    
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return mapper;
+    }
+}

--- a/infrastructure/inventory-event-kafka/src/main/java/com/commerce/inventory/infrastructure/event/kafka/AggregateEvent.java
+++ b/infrastructure/inventory-event-kafka/src/main/java/com/commerce/inventory/infrastructure/event/kafka/AggregateEvent.java
@@ -1,0 +1,11 @@
+package com.commerce.inventory.infrastructure.event.kafka;
+
+/**
+ * Aggregate에 속하는 이벤트를 위한 인터페이스
+ */
+public interface AggregateEvent {
+    String getAggregateId();
+    default String getAggregateType() {
+        return this.getClass().getSimpleName().replace("Event", "");
+    }
+}

--- a/infrastructure/inventory-event-kafka/src/main/java/com/commerce/inventory/infrastructure/event/kafka/KafkaErrorHandler.java
+++ b/infrastructure/inventory-event-kafka/src/main/java/com/commerce/inventory/infrastructure/event/kafka/KafkaErrorHandler.java
@@ -1,0 +1,157 @@
+package com.commerce.inventory.infrastructure.event.kafka;
+
+import com.commerce.common.event.DomainEvent;
+import com.commerce.inventory.infrastructure.event.kafka.retry.RetryableEventStore;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Kafka 이벤트 발행 실패 시 에러 처리
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaErrorHandler {
+    
+    private final RetryableEventStore retryableEventStore;
+    private final ScheduledExecutorService scheduledExecutor = new ScheduledThreadPoolExecutor(2);
+    
+    @Value("${kafka.producer.retry.max-attempts:3}")
+    private int maxRetryAttempts;
+    
+    @Value("${kafka.producer.retry.initial-delay-ms:1000}")
+    private long initialDelayMs;
+    
+    @Value("${kafka.producer.retry.max-delay-ms:60000}")
+    private long maxDelayMs;
+    
+    @Value("${kafka.producer.retry.multiplier:2}")
+    private double delayMultiplier;
+    
+    /**
+     * 이벤트 발행 실패 처리
+     */
+    public void handleError(DomainEvent event, Throwable error) {
+        log.error("Failed to publish event: {}, Error: {}", event.eventType(), error.getMessage());
+        
+        if (isRetryableError(error)) {
+            scheduleRetry(event, 1);
+        } else {
+            handleNonRetryableError(event, error);
+        }
+    }
+    
+    /**
+     * 재시도 가능한 에러인지 판단
+     */
+    private boolean isRetryableError(Throwable error) {
+        // 네트워크 오류, 타임아웃 등 재시도 가능한 에러 판단
+        String errorMessage = error.getMessage();
+        if (errorMessage == null) {
+            return false;
+        }
+        
+        return errorMessage.contains("TimeoutException") ||
+               errorMessage.contains("NetworkException") ||
+               errorMessage.contains("NotLeaderForPartitionException") ||
+               errorMessage.contains("RecordTooLargeException") == false;
+    }
+    
+    /**
+     * 재시도 스케줄링
+     */
+    private void scheduleRetry(DomainEvent event, int attemptNumber) {
+        if (attemptNumber > maxRetryAttempts) {
+            log.error("Max retry attempts ({}) exceeded for event: {}", 
+                maxRetryAttempts, event.eventType());
+            handleMaxRetriesExceeded(event);
+            return;
+        }
+        
+        long delay = calculateDelay(attemptNumber);
+        
+        log.info("Scheduling retry #{} for event: {} after {} ms", 
+            attemptNumber, event.eventType(), delay);
+        
+        scheduledExecutor.schedule(() -> {
+            try {
+                retryableEventStore.retry(event);
+            } catch (Exception e) {
+                log.error("Retry #{} failed for event: {}", attemptNumber, event.eventType(), e);
+                scheduleRetry(event, attemptNumber + 1);
+            }
+        }, delay, TimeUnit.MILLISECONDS);
+    }
+    
+    /**
+     * 지수 백오프를 사용한 재시도 지연 시간 계산
+     */
+    private long calculateDelay(int attemptNumber) {
+        long delay = (long) (initialDelayMs * Math.pow(delayMultiplier, attemptNumber - 1));
+        return Math.min(delay, maxDelayMs);
+    }
+    
+    /**
+     * 재시도 불가능한 에러 처리
+     */
+    private void handleNonRetryableError(DomainEvent event, Throwable error) {
+        log.error("Non-retryable error for event: {}, Error: {}", 
+            event.eventType(), error.getMessage());
+        
+        // Dead Letter Queue로 이동
+        retryableEventStore.moveToDeadLetter(event, error.getMessage());
+        
+        // 알림 발송 (선택적)
+        notifyFailure(event, error);
+    }
+    
+    /**
+     * 최대 재시도 횟수 초과 처리
+     */
+    private void handleMaxRetriesExceeded(DomainEvent event) {
+        // Dead Letter Queue로 이동
+        retryableEventStore.moveToDeadLetter(event, "Max retries exceeded");
+        
+        // 알림 발송
+        notifyMaxRetriesExceeded(event);
+    }
+    
+    /**
+     * 실패 알림 발송
+     */
+    private void notifyFailure(DomainEvent event, Throwable error) {
+        // 실제 구현에서는 모니터링 시스템이나 알림 서비스로 전송
+        log.warn("Event publishing failed permanently. Event: {}, Error: {}", 
+            event.eventType(), error.getMessage());
+    }
+    
+    /**
+     * 최대 재시도 초과 알림
+     */
+    private void notifyMaxRetriesExceeded(DomainEvent event) {
+        // 실제 구현에서는 모니터링 시스템이나 알림 서비스로 전송
+        log.warn("Max retries exceeded for event: {}", event.eventType());
+    }
+    
+    /**
+     * 리소스 정리
+     */
+    public void shutdown() {
+        scheduledExecutor.shutdown();
+        try {
+            if (!scheduledExecutor.awaitTermination(60, TimeUnit.SECONDS)) {
+                scheduledExecutor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            scheduledExecutor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/infrastructure/inventory-event-kafka/src/main/java/com/commerce/inventory/infrastructure/event/kafka/KafkaEventPublisher.java
+++ b/infrastructure/inventory-event-kafka/src/main/java/com/commerce/inventory/infrastructure/event/kafka/KafkaEventPublisher.java
@@ -1,0 +1,91 @@
+package com.commerce.inventory.infrastructure.event.kafka;
+
+import com.commerce.common.event.DomainEvent;
+import com.commerce.inventory.application.service.port.out.EventPublisher;
+import com.commerce.inventory.infrastructure.event.kafka.retry.RetryableEventStore;
+import com.commerce.inventory.infrastructure.event.serialization.EventMessage;
+import com.commerce.inventory.infrastructure.event.serialization.EventSerializer;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Kafka를 사용한 EventPublisher 구현체
+ * 도메인 이벤트를 Kafka 토픽으로 발행합니다.
+ */
+@Slf4j
+@Component("kafkaEventPublisher")
+@RequiredArgsConstructor
+public class KafkaEventPublisher implements EventPublisher {
+    
+    private final KafkaTemplate<String, EventMessage> kafkaTemplate;
+    private final EventSerializer eventSerializer;
+    private final KafkaTopicResolver topicResolver;
+    private final KafkaErrorHandler errorHandler;
+    private final RetryableEventStore retryableEventStore;
+    
+    @PostConstruct
+    public void init() {
+        // RetryableEventStore에 publish 함수 설정
+        retryableEventStore.setRetryPublisher(this::publish);
+    }
+    
+    @Override
+    public void publish(DomainEvent event) {
+        try {
+            String topic = topicResolver.resolveTopic(event);
+            EventMessage message = eventSerializer.serialize(event);
+            String key = generateKey(event);
+            
+            log.debug("Publishing event to topic: {}, key: {}, eventType: {}", 
+                topic, key, event.eventType());
+            
+            CompletableFuture<SendResult<String, EventMessage>> future = 
+                kafkaTemplate.send(topic, key, message);
+            
+            future.whenComplete((result, ex) -> {
+                if (ex != null) {
+                    handlePublishError(event, ex);
+                } else {
+                    handlePublishSuccess(event, result);
+                }
+            });
+            
+        } catch (Exception e) {
+            log.error("Failed to publish event: {}", event, e);
+            errorHandler.handleError(event, e);
+        }
+    }
+    
+    @Override
+    public void publishAll(List<DomainEvent> events) {
+        events.forEach(this::publish);
+    }
+    
+    private String generateKey(DomainEvent event) {
+        // Extract aggregate ID from event for partitioning
+        if (event instanceof AggregateEvent) {
+            return ((AggregateEvent) event).getAggregateId();
+        }
+        // Default to event type for non-aggregate events
+        return event.eventType();
+    }
+    
+    private void handlePublishSuccess(DomainEvent event, SendResult<String, EventMessage> result) {
+        log.info("Successfully published event: {} to partition: {} at offset: {}",
+            event.eventType(),
+            result.getRecordMetadata().partition(),
+            result.getRecordMetadata().offset());
+    }
+    
+    private void handlePublishError(DomainEvent event, Throwable error) {
+        log.error("Failed to publish event: {}", event.eventType(), error);
+        errorHandler.handleError(event, error);
+    }
+}

--- a/infrastructure/inventory-event-kafka/src/main/java/com/commerce/inventory/infrastructure/event/kafka/KafkaTopicResolver.java
+++ b/infrastructure/inventory-event-kafka/src/main/java/com/commerce/inventory/infrastructure/event/kafka/KafkaTopicResolver.java
@@ -1,0 +1,89 @@
+package com.commerce.inventory.infrastructure.event.kafka;
+
+import com.commerce.common.event.DomainEvent;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 이벤트 타입에 따른 Kafka 토픽 결정
+ */
+@Component
+public class KafkaTopicResolver {
+    
+    @Value("${kafka.topics.prefix:inventory}")
+    private String topicPrefix;
+    
+    @Value("${kafka.topics.default:inventory-events}")
+    private String defaultTopic;
+    
+    private final Map<String, String> topicMappings = new ConcurrentHashMap<>();
+    
+    public KafkaTopicResolver() {
+        // 이벤트 타입별 토픽 매핑 초기화
+        initializeTopicMappings();
+    }
+    
+    /**
+     * 도메인 이벤트에 대한 Kafka 토픽 결정
+     */
+    public String resolveTopic(DomainEvent event) {
+        String eventType = event.eventType();
+        
+        // 명시적 매핑이 있는 경우
+        if (topicMappings.containsKey(eventType)) {
+            return topicMappings.get(eventType);
+        }
+        
+        // 이벤트 타입 기반 토픽 생성
+        return generateTopicName(eventType);
+    }
+    
+    /**
+     * 이벤트 타입별 토픽 매핑 초기화
+     */
+    private void initializeTopicMappings() {
+        // Stock 관련 이벤트
+        topicMappings.put("StockReceivedEvent", "inventory-stock-events");
+        topicMappings.put("StockReservedEvent", "inventory-stock-events");
+        topicMappings.put("StockDepletedEvent", "inventory-stock-events");
+        topicMappings.put("ReservationReleasedEvent", "inventory-stock-events");
+        
+        // SKU 관련 이벤트
+        topicMappings.put("SkuCreatedEvent", "inventory-sku-events");
+        topicMappings.put("SkuUpdatedEvent", "inventory-sku-events");
+        topicMappings.put("SkuDeletedEvent", "inventory-sku-events");
+        
+        // Movement 관련 이벤트
+        topicMappings.put("StockMovementCreatedEvent", "inventory-movement-events");
+    }
+    
+    /**
+     * 이벤트 타입으로부터 토픽 이름 생성
+     */
+    private String generateTopicName(String eventType) {
+        // EventType이 "StockReceivedEvent"인 경우 -> "inventory-stock-received"
+        String topicSuffix = eventType
+            .replaceAll("Event$", "")
+            .replaceAll("([a-z])([A-Z])", "$1-$2")
+            .toLowerCase();
+        
+        return topicPrefix + "-" + topicSuffix;
+    }
+    
+    /**
+     * 특정 이벤트 타입에 대한 토픽 매핑 추가
+     */
+    public void addMapping(String eventType, String topic) {
+        topicMappings.put(eventType, topic);
+    }
+    
+    /**
+     * 특정 이벤트 타입에 대한 토픽 매핑 제거
+     */
+    public void removeMapping(String eventType) {
+        topicMappings.remove(eventType);
+    }
+}

--- a/infrastructure/inventory-event-kafka/src/main/java/com/commerce/inventory/infrastructure/event/kafka/retry/DeadLetterEvent.java
+++ b/infrastructure/inventory-event-kafka/src/main/java/com/commerce/inventory/infrastructure/event/kafka/retry/DeadLetterEvent.java
@@ -1,0 +1,23 @@
+package com.commerce.inventory.infrastructure.event.kafka.retry;
+
+import com.commerce.common.event.DomainEvent;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Dead Letter Queue의 이벤트 정보
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeadLetterEvent {
+    private String id;
+    private DomainEvent event;
+    private String reason;
+    private LocalDateTime movedAt;
+}

--- a/infrastructure/inventory-event-kafka/src/main/java/com/commerce/inventory/infrastructure/event/kafka/retry/FailedEvent.java
+++ b/infrastructure/inventory-event-kafka/src/main/java/com/commerce/inventory/infrastructure/event/kafka/retry/FailedEvent.java
@@ -1,0 +1,30 @@
+package com.commerce.inventory.infrastructure.event.kafka.retry;
+
+import com.commerce.common.event.DomainEvent;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 실패한 이벤트 정보
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FailedEvent {
+    private String id;
+    private DomainEvent event;
+    private String failureReason;
+    private LocalDateTime failedAt;
+    private int retryCount;
+    private LocalDateTime lastRetryAt;
+    
+    public void incrementRetryCount() {
+        this.retryCount++;
+        this.lastRetryAt = LocalDateTime.now();
+    }
+}

--- a/infrastructure/inventory-event-kafka/src/main/java/com/commerce/inventory/infrastructure/event/kafka/retry/RetryableEventStore.java
+++ b/infrastructure/inventory-event-kafka/src/main/java/com/commerce/inventory/infrastructure/event/kafka/retry/RetryableEventStore.java
@@ -1,0 +1,133 @@
+package com.commerce.inventory.infrastructure.event.kafka.retry;
+
+import com.commerce.common.event.DomainEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+/**
+ * 재시도 가능한 이벤트 저장소
+ * 실패한 이벤트를 임시 저장하고 재시도를 관리합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RetryableEventStore {
+    
+    private final ObjectMapper objectMapper;
+    
+    @Setter
+    private Consumer<DomainEvent> retryPublisher;
+    
+    // In-memory store for failed events (실제 환경에서는 Redis나 DB 사용 권장)
+    private final Map<String, FailedEvent> failedEvents = new ConcurrentHashMap<>();
+    private final Map<String, DeadLetterEvent> deadLetterQueue = new ConcurrentHashMap<>();
+    
+    /**
+     * 이벤트 재시도
+     */
+    public void retry(DomainEvent event) {
+        log.info("Retrying event: {}", event.eventType());
+        if (retryPublisher != null) {
+            retryPublisher.accept(event);
+        } else {
+            log.error("Retry publisher not set for event: {}", event.eventType());
+        }
+    }
+    
+    /**
+     * 실패한 이벤트 저장
+     */
+    public void storeFailedEvent(DomainEvent event, String reason) {
+        String id = UUID.randomUUID().toString();
+        FailedEvent failedEvent = FailedEvent.builder()
+            .id(id)
+            .event(event)
+            .failureReason(reason)
+            .failedAt(LocalDateTime.now())
+            .retryCount(0)
+            .build();
+        
+        failedEvents.put(id, failedEvent);
+        log.info("Stored failed event: {} with id: {}", event.eventType(), id);
+    }
+    
+    /**
+     * Dead Letter Queue로 이동
+     */
+    public void moveToDeadLetter(DomainEvent event, String reason) {
+        String id = UUID.randomUUID().toString();
+        DeadLetterEvent deadLetterEvent = DeadLetterEvent.builder()
+            .id(id)
+            .event(event)
+            .reason(reason)
+            .movedAt(LocalDateTime.now())
+            .build();
+        
+        deadLetterQueue.put(id, deadLetterEvent);
+        log.warn("Moved event to DLQ: {} with id: {}", event.eventType(), id);
+    }
+    
+    /**
+     * 실패한 이벤트 조회
+     */
+    public Map<String, FailedEvent> getFailedEvents() {
+        return new ConcurrentHashMap<>(failedEvents);
+    }
+    
+    /**
+     * Dead Letter Queue 조회
+     */
+    public Map<String, DeadLetterEvent> getDeadLetterQueue() {
+        return new ConcurrentHashMap<>(deadLetterQueue);
+    }
+    
+    /**
+     * 실패한 이벤트 제거
+     */
+    public void removeFailedEvent(String id) {
+        failedEvents.remove(id);
+    }
+    
+    /**
+     * Dead Letter Queue에서 제거
+     */
+    public void removeFromDeadLetter(String id) {
+        deadLetterQueue.remove(id);
+    }
+    
+    /**
+     * 모든 실패한 이벤트 재시도
+     */
+    public void retryAllFailedEvents() {
+        failedEvents.values().forEach(failedEvent -> {
+            try {
+                retry(failedEvent.getEvent());
+                removeFailedEvent(failedEvent.getId());
+            } catch (Exception e) {
+                log.error("Failed to retry event: {}", failedEvent.getId(), e);
+                failedEvent.incrementRetryCount();
+            }
+        });
+    }
+    
+    /**
+     * Dead Letter Queue의 이벤트를 재시도 큐로 이동
+     */
+    public void reprocessDeadLetterEvent(String id) {
+        DeadLetterEvent deadLetterEvent = deadLetterQueue.get(id);
+        if (deadLetterEvent != null) {
+            storeFailedEvent(deadLetterEvent.getEvent(), "Reprocessing from DLQ");
+            removeFromDeadLetter(id);
+            log.info("Moved event from DLQ to retry queue: {}", id);
+        }
+    }
+}

--- a/infrastructure/inventory-event-kafka/src/main/java/com/commerce/inventory/infrastructure/event/serialization/EventMessage.java
+++ b/infrastructure/inventory-event-kafka/src/main/java/com/commerce/inventory/infrastructure/event/serialization/EventMessage.java
@@ -1,0 +1,39 @@
+package com.commerce.inventory.infrastructure.event.serialization;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Kafka로 전송될 이벤트 메시지 포맷
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventMessage {
+    
+    private String eventId;
+    private String eventType;
+    private String aggregateId;
+    private String aggregateType;
+    private LocalDateTime occurredAt;
+    private Map<String, Object> payload;
+    private Map<String, String> metadata;
+    private Integer version;
+    
+    public static EventMessage create(String eventType, Map<String, Object> payload) {
+        return EventMessage.builder()
+            .eventId(UUID.randomUUID().toString())
+            .eventType(eventType)
+            .payload(payload)
+            .occurredAt(LocalDateTime.now())
+            .version(1)
+            .build();
+    }
+}

--- a/infrastructure/inventory-event-kafka/src/main/java/com/commerce/inventory/infrastructure/event/serialization/EventSerializationException.java
+++ b/infrastructure/inventory-event-kafka/src/main/java/com/commerce/inventory/infrastructure/event/serialization/EventSerializationException.java
@@ -1,0 +1,15 @@
+package com.commerce.inventory.infrastructure.event.serialization;
+
+/**
+ * 이벤트 직렬화 중 발생하는 예외
+ */
+public class EventSerializationException extends RuntimeException {
+    
+    public EventSerializationException(String message) {
+        super(message);
+    }
+    
+    public EventSerializationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/infrastructure/inventory-event-kafka/src/main/java/com/commerce/inventory/infrastructure/event/serialization/EventSerializer.java
+++ b/infrastructure/inventory-event-kafka/src/main/java/com/commerce/inventory/infrastructure/event/serialization/EventSerializer.java
@@ -1,0 +1,105 @@
+package com.commerce.inventory.infrastructure.event.serialization;
+
+import com.commerce.common.event.DomainEvent;
+import com.commerce.inventory.infrastructure.event.kafka.AggregateEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 도메인 이벤트를 Kafka 메시지로 변환하는 직렬화 클래스
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EventSerializer {
+    
+    private final ObjectMapper objectMapper;
+    
+    /**
+     * DomainEvent를 EventMessage로 직렬화
+     */
+    public EventMessage serialize(DomainEvent event) {
+        try {
+            Map<String, Object> payload = convertToMap(event);
+            
+            return EventMessage.builder()
+                .eventId(UUID.randomUUID().toString())
+                .eventType(event.eventType())
+                .occurredAt(event.getOccurredAt())
+                .payload(payload)
+                .metadata(extractMetadata(event))
+                .aggregateId(extractAggregateId(event))
+                .aggregateType(extractAggregateType(event))
+                .version(1)
+                .build();
+                
+        } catch (Exception e) {
+            log.error("Failed to serialize event: {}", event, e);
+            throw new EventSerializationException("Failed to serialize event", e);
+        }
+    }
+    
+    /**
+     * EventMessage를 특정 타입의 DomainEvent로 역직렬화
+     */
+    public <T extends DomainEvent> T deserialize(EventMessage message, Class<T> eventClass) {
+        try {
+            return objectMapper.convertValue(message.getPayload(), eventClass);
+        } catch (Exception e) {
+            log.error("Failed to deserialize event message: {}", message, e);
+            throw new EventSerializationException("Failed to deserialize event message", e);
+        }
+    }
+    
+    private Map<String, Object> convertToMap(DomainEvent event) {
+        try {
+            // Convert event object to Map
+            @SuppressWarnings("unchecked")
+            Map<String, Object> map = objectMapper.convertValue(event, Map.class);
+            return map;
+        } catch (Exception e) {
+            log.error("Failed to convert event to map: {}", event, e);
+            throw new EventSerializationException("Failed to convert event to map", e);
+        }
+    }
+    
+    private Map<String, String> extractMetadata(DomainEvent event) {
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("eventClass", event.getClass().getName());
+        metadata.put("timestamp", event.getOccurredAt().toString());
+        
+        // Add custom metadata if event implements MetadataProvider
+        if (event instanceof MetadataProvider) {
+            metadata.putAll(((MetadataProvider) event).getMetadata());
+        }
+        
+        return metadata;
+    }
+    
+    private String extractAggregateId(DomainEvent event) {
+        if (event instanceof AggregateEvent) {
+            return ((AggregateEvent) event).getAggregateId();
+        }
+        return null;
+    }
+    
+    private String extractAggregateType(DomainEvent event) {
+        if (event instanceof AggregateEvent) {
+            return ((AggregateEvent) event).getAggregateType();
+        }
+        return null;
+    }
+    
+    /**
+     * Interface for events that provide additional metadata
+     */
+    public interface MetadataProvider {
+        Map<String, String> getMetadata();
+    }
+}

--- a/infrastructure/inventory-event-kafka/src/test/java/com/commerce/inventory/infrastructure/event/kafka/KafkaErrorHandlerTest.java
+++ b/infrastructure/inventory-event-kafka/src/test/java/com/commerce/inventory/infrastructure/event/kafka/KafkaErrorHandlerTest.java
@@ -1,0 +1,153 @@
+package com.commerce.inventory.infrastructure.event.kafka;
+
+import com.commerce.common.event.DomainEvent;
+import com.commerce.inventory.infrastructure.event.kafka.retry.RetryableEventStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeoutException;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("KafkaErrorHandler 테스트")
+class KafkaErrorHandlerTest {
+    
+    @Mock
+    private RetryableEventStore retryableEventStore;
+    
+    private KafkaErrorHandler errorHandler;
+    
+    @BeforeEach
+    void setUp() {
+        errorHandler = new KafkaErrorHandler(retryableEventStore);
+        
+        // Set test configuration values
+        ReflectionTestUtils.setField(errorHandler, "maxRetryAttempts", 3);
+        ReflectionTestUtils.setField(errorHandler, "initialDelayMs", 100L);
+        ReflectionTestUtils.setField(errorHandler, "maxDelayMs", 1000L);
+        ReflectionTestUtils.setField(errorHandler, "delayMultiplier", 2.0);
+    }
+    
+    @Test
+    @DisplayName("재시도 가능한 에러인 경우 재시도를 스케줄링한다")
+    void testHandleError_RetryableError() throws InterruptedException {
+        // Given
+        TestDomainEvent event = new TestDomainEvent();
+        TimeoutException error = new TimeoutException("Network timeout");
+        
+        // When
+        errorHandler.handleError(event, error);
+        
+        // Then - wait for scheduled retry
+        Thread.sleep(200);
+        verify(retryableEventStore, atLeastOnce()).retry(event);
+    }
+    
+    @Test
+    @DisplayName("재시도 불가능한 에러인 경우 DLQ로 이동한다")
+    void testHandleError_NonRetryableError() {
+        // Given
+        TestDomainEvent event = new TestDomainEvent();
+        IllegalArgumentException error = new IllegalArgumentException("Invalid argument");
+        
+        // When
+        errorHandler.handleError(event, error);
+        
+        // Then
+        verify(retryableEventStore).moveToDeadLetter(eq(event), contains("Invalid argument"));
+        verify(retryableEventStore, never()).retry(any());
+    }
+    
+    @Test
+    @DisplayName("RecordTooLargeException은 재시도하지 않는다")
+    void testHandleError_RecordTooLarge() {
+        // Given
+        TestDomainEvent event = new TestDomainEvent();
+        RuntimeException error = new RuntimeException("RecordTooLargeException: Message too large");
+        
+        // When
+        errorHandler.handleError(event, error);
+        
+        // Then
+        verify(retryableEventStore).moveToDeadLetter(eq(event), anyString());
+        verify(retryableEventStore, never()).retry(any());
+    }
+    
+    @Test
+    @DisplayName("NetworkException은 재시도한다")
+    void testHandleError_NetworkException() throws InterruptedException {
+        // Given
+        TestDomainEvent event = new TestDomainEvent();
+        RuntimeException error = new RuntimeException("NetworkException: Connection failed");
+        
+        // When
+        errorHandler.handleError(event, error);
+        
+        // Then - wait for scheduled retry
+        Thread.sleep(200);
+        verify(retryableEventStore, atLeastOnce()).retry(event);
+    }
+    
+    @Test
+    @DisplayName("NotLeaderForPartitionException은 재시도한다")
+    void testHandleError_NotLeaderForPartition() throws InterruptedException {
+        // Given
+        TestDomainEvent event = new TestDomainEvent();
+        RuntimeException error = new RuntimeException("NotLeaderForPartitionException");
+        
+        // When
+        errorHandler.handleError(event, error);
+        
+        // Then - wait for scheduled retry
+        Thread.sleep(200);
+        verify(retryableEventStore, atLeastOnce()).retry(event);
+    }
+    
+    @Test
+    @DisplayName("null 메시지를 가진 에러는 재시도하지 않는다")
+    void testHandleError_NullMessage() {
+        // Given
+        TestDomainEvent event = new TestDomainEvent();
+        RuntimeException error = new RuntimeException((String) null);
+        
+        // When
+        errorHandler.handleError(event, error);
+        
+        // Then
+        verify(retryableEventStore).moveToDeadLetter(eq(event), anyString());
+        verify(retryableEventStore, never()).retry(any());
+    }
+    
+    @Test
+    @DisplayName("shutdown 메서드가 정상적으로 실행된다")
+    void testShutdown() {
+        // When
+        errorHandler.shutdown();
+        
+        // Then - no exception should be thrown
+        // This test verifies that shutdown completes without error
+    }
+    
+    // Test event class
+    static class TestDomainEvent implements DomainEvent {
+        private final LocalDateTime occurredAt = LocalDateTime.now();
+        
+        @Override
+        public LocalDateTime getOccurredAt() {
+            return occurredAt;
+        }
+        
+        @Override
+        public String eventType() {
+            return "TestDomainEvent";
+        }
+    }
+}

--- a/infrastructure/inventory-event-kafka/src/test/java/com/commerce/inventory/infrastructure/event/kafka/KafkaEventPublisherTest.java
+++ b/infrastructure/inventory-event-kafka/src/test/java/com/commerce/inventory/infrastructure/event/kafka/KafkaEventPublisherTest.java
@@ -1,0 +1,220 @@
+package com.commerce.inventory.infrastructure.event.kafka;
+
+import com.commerce.common.event.DomainEvent;
+import com.commerce.inventory.infrastructure.event.kafka.retry.RetryableEventStore;
+import com.commerce.inventory.infrastructure.event.serialization.EventMessage;
+import com.commerce.inventory.infrastructure.event.serialization.EventSerializer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("KafkaEventPublisher 테스트")
+class KafkaEventPublisherTest {
+    
+    @Mock
+    private KafkaTemplate<String, EventMessage> kafkaTemplate;
+    
+    @Mock
+    private EventSerializer eventSerializer;
+    
+    @Mock
+    private KafkaTopicResolver topicResolver;
+    
+    @Mock
+    private KafkaErrorHandler errorHandler;
+    
+    @Mock
+    private RetryableEventStore retryableEventStore;
+    
+    private KafkaEventPublisher eventPublisher;
+    
+    @BeforeEach
+    void setUp() {
+        eventPublisher = new KafkaEventPublisher(
+            kafkaTemplate,
+            eventSerializer,
+            topicResolver,
+            errorHandler,
+            retryableEventStore
+        );
+        eventPublisher.init();
+    }
+    
+    @Test
+    @DisplayName("도메인 이벤트를 성공적으로 발행한다")
+    void testPublish_Success() {
+        // Given
+        TestDomainEvent event = new TestDomainEvent("aggregate-123");
+        String topic = "test-topic";
+        EventMessage message = createEventMessage();
+        
+        when(topicResolver.resolveTopic(event)).thenReturn(topic);
+        when(eventSerializer.serialize(event)).thenReturn(message);
+        
+        CompletableFuture<SendResult<String, EventMessage>> future = 
+            CompletableFuture.completedFuture(mock(SendResult.class));
+        when(kafkaTemplate.send(eq(topic), any(String.class), eq(message)))
+            .thenReturn(future);
+        
+        // When
+        eventPublisher.publish(event);
+        
+        // Then
+        verify(topicResolver).resolveTopic(event);
+        verify(eventSerializer).serialize(event);
+        verify(kafkaTemplate).send(eq(topic), eq("aggregate-123"), eq(message));
+        verify(errorHandler, never()).handleError(any(), any());
+    }
+    
+    @Test
+    @DisplayName("이벤트 발행 실패 시 에러 핸들러를 호출한다")
+    void testPublish_Failure() {
+        // Given
+        TestDomainEvent event = new TestDomainEvent("aggregate-123");
+        String topic = "test-topic";
+        EventMessage message = createEventMessage();
+        RuntimeException error = new RuntimeException("Kafka error");
+        
+        when(topicResolver.resolveTopic(event)).thenReturn(topic);
+        when(eventSerializer.serialize(event)).thenReturn(message);
+        
+        CompletableFuture<SendResult<String, EventMessage>> future = new CompletableFuture<>();
+        future.completeExceptionally(error);
+        when(kafkaTemplate.send(eq(topic), any(String.class), eq(message)))
+            .thenReturn(future);
+        
+        // When
+        eventPublisher.publish(event);
+        
+        // Then
+        verify(kafkaTemplate).send(eq(topic), eq("aggregate-123"), eq(message));
+        verify(errorHandler, timeout(1000)).handleError(eq(event), any(Throwable.class));
+    }
+    
+    @Test
+    @DisplayName("여러 이벤트를 순차적으로 발행한다")
+    void testPublishAll() {
+        // Given
+        TestDomainEvent event1 = new TestDomainEvent("aggregate-1");
+        TestDomainEvent event2 = new TestDomainEvent("aggregate-2");
+        List<DomainEvent> events = Arrays.asList(event1, event2);
+        
+        when(topicResolver.resolveTopic(any())).thenReturn("test-topic");
+        when(eventSerializer.serialize(any())).thenReturn(createEventMessage());
+        
+        CompletableFuture<SendResult<String, EventMessage>> future = 
+            CompletableFuture.completedFuture(mock(SendResult.class));
+        when(kafkaTemplate.send(anyString(), anyString(), any(EventMessage.class)))
+            .thenReturn(future);
+        
+        // When
+        eventPublisher.publishAll(events);
+        
+        // Then
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), any(EventMessage.class));
+        verify(eventSerializer, times(2)).serialize(any(DomainEvent.class));
+    }
+    
+    @Test
+    @DisplayName("Aggregate 이벤트의 경우 aggregateId를 키로 사용한다")
+    void testPublish_WithAggregateEvent() {
+        // Given
+        TestAggregateEvent event = new TestAggregateEvent("aggregate-456");
+        String topic = "test-topic";
+        EventMessage message = createEventMessage();
+        
+        when(topicResolver.resolveTopic(event)).thenReturn(topic);
+        when(eventSerializer.serialize(event)).thenReturn(message);
+        
+        CompletableFuture<SendResult<String, EventMessage>> future = 
+            CompletableFuture.completedFuture(mock(SendResult.class));
+        when(kafkaTemplate.send(eq(topic), eq("aggregate-456"), eq(message)))
+            .thenReturn(future);
+        
+        // When
+        eventPublisher.publish(event);
+        
+        // Then
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate).send(eq(topic), keyCaptor.capture(), eq(message));
+        assertThat(keyCaptor.getValue()).isEqualTo("aggregate-456");
+    }
+    
+    @Test
+    @DisplayName("직렬화 실패 시 에러 핸들러를 호출한다")
+    void testPublish_SerializationFailure() {
+        // Given
+        TestDomainEvent event = new TestDomainEvent("aggregate-123");
+        RuntimeException error = new RuntimeException("Serialization error");
+        
+        when(topicResolver.resolveTopic(event)).thenReturn("test-topic");
+        when(eventSerializer.serialize(event)).thenThrow(error);
+        
+        // When
+        eventPublisher.publish(event);
+        
+        // Then
+        verify(errorHandler).handleError(event, error);
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), any(EventMessage.class));
+    }
+    
+    private EventMessage createEventMessage() {
+        return EventMessage.builder()
+            .eventId(UUID.randomUUID().toString())
+            .eventType("TestEvent")
+            .occurredAt(LocalDateTime.now())
+            .build();
+    }
+    
+    // Test event classes
+    static class TestDomainEvent implements DomainEvent {
+        private final String id;
+        private final LocalDateTime occurredAt = LocalDateTime.now();
+        
+        TestDomainEvent(String id) {
+            this.id = id;
+        }
+        
+        @Override
+        public LocalDateTime getOccurredAt() {
+            return occurredAt;
+        }
+        
+        @Override
+        public String eventType() {
+            return "TestDomainEvent";
+        }
+    }
+    
+    static class TestAggregateEvent extends TestDomainEvent implements AggregateEvent {
+        private final String aggregateId;
+        
+        TestAggregateEvent(String aggregateId) {
+            super(aggregateId);
+            this.aggregateId = aggregateId;
+        }
+        
+        @Override
+        public String getAggregateId() {
+            return aggregateId;
+        }
+    }
+}

--- a/infrastructure/inventory-event-kafka/src/test/java/com/commerce/inventory/infrastructure/event/serialization/EventSerializerTest.java
+++ b/infrastructure/inventory-event-kafka/src/test/java/com/commerce/inventory/infrastructure/event/serialization/EventSerializerTest.java
@@ -1,0 +1,228 @@
+package com.commerce.inventory.infrastructure.event.serialization;
+
+import com.commerce.common.event.DomainEvent;
+import com.commerce.inventory.infrastructure.event.kafka.AggregateEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("EventSerializer 테스트")
+class EventSerializerTest {
+    
+    private EventSerializer eventSerializer;
+    private ObjectMapper objectMapper;
+    
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        eventSerializer = new EventSerializer(objectMapper);
+    }
+    
+    @Test
+    @DisplayName("도메인 이벤트를 EventMessage로 직렬화한다")
+    void testSerialize() {
+        // Given
+        TestDomainEvent event = new TestDomainEvent("test-id", "test data");
+        
+        // When
+        EventMessage message = eventSerializer.serialize(event);
+        
+        // Then
+        assertThat(message).isNotNull();
+        assertThat(message.getEventId()).isNotNull();
+        assertThat(message.getEventType()).isEqualTo("TestDomainEvent");
+        assertThat(message.getOccurredAt()).isNotNull();
+        assertThat(message.getPayload()).isNotNull();
+        assertThat(message.getMetadata()).containsKey("eventClass");
+        assertThat(message.getMetadata()).containsKey("timestamp");
+        assertThat(message.getVersion()).isEqualTo(1);
+    }
+    
+    @Test
+    @DisplayName("AggregateEvent를 직렬화할 때 aggregateId와 aggregateType을 포함한다")
+    void testSerializeAggregateEvent() {
+        // Given
+        TestAggregateEvent event = new TestAggregateEvent("agg-123", "test data");
+        
+        // When
+        EventMessage message = eventSerializer.serialize(event);
+        
+        // Then
+        assertThat(message.getAggregateId()).isEqualTo("agg-123");
+        assertThat(message.getAggregateType()).isEqualTo("TestAggregate");
+    }
+    
+    @Test
+    @DisplayName("MetadataProvider를 구현한 이벤트는 추가 메타데이터를 포함한다")
+    void testSerializeWithMetadataProvider() {
+        // Given
+        TestEventWithMetadata event = new TestEventWithMetadata("test-id");
+        
+        // When
+        EventMessage message = eventSerializer.serialize(event);
+        
+        // Then
+        assertThat(message.getMetadata()).containsEntry("customKey", "customValue");
+        assertThat(message.getMetadata()).containsEntry("userId", "user-123");
+    }
+    
+    @Test
+    @DisplayName("EventMessage를 DomainEvent로 역직렬화한다")
+    void testDeserialize() {
+        // Given
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("id", "test-id");
+        payload.put("data", "test data");
+        payload.put("occurredAt", LocalDateTime.now().toString());
+        
+        EventMessage message = EventMessage.builder()
+            .eventId("event-123")
+            .eventType("TestDomainEvent")
+            .payload(payload)
+            .occurredAt(LocalDateTime.now())
+            .build();
+        
+        // When
+        TestDomainEvent event = eventSerializer.deserialize(message, TestDomainEvent.class);
+        
+        // Then
+        assertThat(event).isNotNull();
+        assertThat(event.getId()).isEqualTo("test-id");
+        assertThat(event.getData()).isEqualTo("test data");
+    }
+    
+    @Test
+    @DisplayName("직렬화 실패 시 EventSerializationException을 던진다")
+    void testSerializeFailure() {
+        // Given
+        InvalidEvent event = new InvalidEvent();
+        
+        // When & Then
+        assertThatThrownBy(() -> eventSerializer.serialize(event))
+            .isInstanceOf(EventSerializationException.class)
+            .hasMessageContaining("Failed to serialize event");
+    }
+    
+    @Test
+    @DisplayName("역직렬화 실패 시 EventSerializationException을 던진다")
+    void testDeserializeFailure() {
+        // Given
+        Map<String, Object> invalidPayload = new HashMap<>();
+        invalidPayload.put("invalid", "data");
+        
+        EventMessage message = EventMessage.builder()
+            .eventId("event-123")
+            .eventType("InvalidEvent")
+            .payload(invalidPayload)
+            .build();
+        
+        // When & Then
+        assertThatThrownBy(() -> eventSerializer.deserialize(message, TestDomainEvent.class))
+            .isInstanceOf(EventSerializationException.class)
+            .hasMessageContaining("Failed to deserialize event message");
+    }
+    
+    // Test event classes
+    static class TestDomainEvent implements DomainEvent {
+        private String id;
+        private String data;
+        private LocalDateTime occurredAt;
+        
+        public TestDomainEvent() {
+            this.occurredAt = LocalDateTime.now();
+        }
+        
+        public TestDomainEvent(String id, String data) {
+            this.id = id;
+            this.data = data;
+            this.occurredAt = LocalDateTime.now();
+        }
+        
+        @Override
+        public LocalDateTime getOccurredAt() {
+            return occurredAt;
+        }
+        
+        @Override
+        public String eventType() {
+            return "TestDomainEvent";
+        }
+        
+        public String getId() {
+            return id;
+        }
+        
+        public void setId(String id) {
+            this.id = id;
+        }
+        
+        public String getData() {
+            return data;
+        }
+        
+        public void setData(String data) {
+            this.data = data;
+        }
+        
+        public void setOccurredAt(LocalDateTime occurredAt) {
+            this.occurredAt = occurredAt;
+        }
+    }
+    
+    static class TestAggregateEvent extends TestDomainEvent implements AggregateEvent {
+        private final String aggregateId;
+        
+        public TestAggregateEvent(String aggregateId, String data) {
+            super(aggregateId, data);
+            this.aggregateId = aggregateId;
+        }
+        
+        @Override
+        public String getAggregateId() {
+            return aggregateId;
+        }
+        
+        @Override
+        public String getAggregateType() {
+            return "TestAggregate";
+        }
+    }
+    
+    static class TestEventWithMetadata extends TestDomainEvent implements EventSerializer.MetadataProvider {
+        public TestEventWithMetadata(String id) {
+            super(id, "test");
+        }
+        
+        @Override
+        public Map<String, String> getMetadata() {
+            Map<String, String> metadata = new HashMap<>();
+            metadata.put("customKey", "customValue");
+            metadata.put("userId", "user-123");
+            return metadata;
+        }
+    }
+    
+    static class InvalidEvent implements DomainEvent {
+        @Override
+        public LocalDateTime getOccurredAt() {
+            throw new RuntimeException("Invalid event");
+        }
+        
+        @Override
+        public String eventType() {
+            return "InvalidEvent";
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,6 +21,9 @@ project(':inventory-persistence').projectDir = file('infrastructure/inventory-pe
 include 'product-kafka'
 project(':product-kafka').projectDir = file('infrastructure/product-kafka')
 
+include 'inventory-event-kafka'
+project(':inventory-event-kafka').projectDir = file('infrastructure/inventory-event-kafka')
+
 // Bootstrap modules
 include 'product-api'
 project(':product-api').projectDir = file('bootstrap/product-api')


### PR DESCRIPTION
## 작업 내용

### Event Publisher 구현 완료
- ✅ KafkaEventPublisher 구현체 작성
- ✅ EventSerializer로 도메인 이벤트를 Kafka 메시지로 변환
- ✅ KafkaErrorHandler로 실패 처리 및 재시도 로직 구현
- ✅ RetryableEventStore로 실패한 이벤트 관리 및 Dead Letter Queue 기능
- ✅ Kafka Producer 설정 클래스 구현
- ✅ 단위 테스트 작성

### 주요 기능
1. **KafkaEventPublisher**
   - EventPublisher 인터페이스 구현
   - 도메인 이벤트를 Kafka 토픽으로 발행
   - 비동기 처리 및 성공/실패 핸들링

2. **EventSerializer**
   - DomainEvent를 EventMessage로 직렬화
   - Aggregate 정보 및 메타데이터 추출
   - JSON 기반 직렬화/역직렬화

3. **Error Handling & Retry**
   - 지수 백오프를 사용한 재시도 메커니즘
   - 재시도 가능/불가능한 에러 구분
   - Dead Letter Queue로 최종 실패 이벤트 이동

4. **Kafka Configuration**
   - Producer 설정 (압축, 배치, idempotence 등)
   - Topic 자동 매핑 및 파티셔닝 전략

### 테스트
- KafkaEventPublisher 테스트 작성
- EventSerializer 테스트 작성
- KafkaErrorHandler 테스트 작성

Closes #68