### PR TITLE
feat(#79): PUT /api/products/{id} 엔드포인트 구현

### DIFF
--- a/bootstrap/product-api/src/main/java/com/commerce/product/api/adapter/in/web/dto/UpdateProductRequest.java
+++ b/bootstrap/product-api/src/main/java/com/commerce/product/api/adapter/in/web/dto/UpdateProductRequest.java
@@ -1,0 +1,32 @@
+package com.commerce.product.api.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateProductRequest {
+    
+    @NotBlank(message = "상품명은 필수입니다")
+    private String name;
+    
+    private String description;
+    
+    @NotNull(message = "버전 정보는 필수입니다")
+    private Long version;
+    
+    public com.commerce.product.application.usecase.UpdateProductRequest toUseCaseRequest(String productId) {
+        return com.commerce.product.application.usecase.UpdateProductRequest.builder()
+                .productId(productId)
+                .name(name)
+                .description(description)
+                .version(version)
+                .build();
+    }
+}

--- a/bootstrap/product-api/src/main/java/com/commerce/product/api/adapter/in/web/dto/UpdateProductResponse.java
+++ b/bootstrap/product-api/src/main/java/com/commerce/product/api/adapter/in/web/dto/UpdateProductResponse.java
@@ -1,0 +1,27 @@
+package com.commerce.product.api.adapter.in.web.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UpdateProductResponse {
+    
+    private final String productId;
+    private final String name;
+    private final String description;
+    private final String type;
+    private final String status;
+    private final Long version;
+    
+    public static UpdateProductResponse from(com.commerce.product.application.usecase.UpdateProductResponse useCaseResponse) {
+        return UpdateProductResponse.builder()
+                .productId(useCaseResponse.getProductId())
+                .name(useCaseResponse.getName())
+                .description(useCaseResponse.getDescription())
+                .type(useCaseResponse.getType())
+                .status(useCaseResponse.getStatus())
+                .version(useCaseResponse.getVersion())
+                .build();
+    }
+}

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -170,8 +170,8 @@ Redis 기반 캐싱
 
 #### 10.1 Product API
 - [x] POST /api/products
-- [ ] GET /api/products/{id}
-- [ ] PUT /api/products/{id}
+- [x] GET /api/products/{id} ✅ 구현 완료
+- [x] PUT /api/products/{id} ✅ 구현 완료
 - [ ] POST /api/products/{id}/options
 - [ ] GET /api/products (검색/필터)
 


### PR DESCRIPTION
## 작업 내용
PUT /api/products/{id} 엔드포인트를 TDD 방식으로 구현했습니다.

## 주요 변경 사항
- UpdateProductRequest/Response DTO 추가
- ProductController에 updateProduct 메서드 구현
- 상품 수정 API 테스트 케이스 작성
  - 정상 수정 테스트
  - 유효성 검증 실패 테스트 (상품명 없음, 버전 정보 없음)
  - 동시 수정 충돌 테스트 (409 Conflict)
  - 존재하지 않는 상품 수정 테스트 (404 Not Found)
  - 설명만 수정하는 테스트

## 테스트 결과
✅ 모든 테스트 통과
- ProductControllerTest.UpdateProduct: 6개 테스트 모두 성공

## 구현 사항
- 낙관적 락을 통한 동시 수정 방지 (version 필드 활용)
- 유효성 검증 (@NotBlank, @NotNull)
- 적절한 HTTP 상태 코드 반환
  - 200 OK: 수정 성공
  - 400 Bad Request: 유효성 검증 실패
  - 404 Not Found: 상품 없음
  - 409 Conflict: 동시 수정 충돌

Closes #79

🤖 Generated with [Claude Code](https://claude.ai/code)