### PR TITLE
feat(#87): 10.3 Category API - POST /api/categories 구현

### DIFF
--- a/bootstrap/product-api/src/main/java/com/commerce/product/api/adapter/in/web/CategoryController.java
+++ b/bootstrap/product-api/src/main/java/com/commerce/product/api/adapter/in/web/CategoryController.java
@@ -1,0 +1,72 @@
+package com.commerce.product.api.adapter.in.web;
+
+import com.commerce.product.api.adapter.in.web.dto.CategoryResponse;
+import com.commerce.product.api.adapter.in.web.dto.CreateCategoryApiRequest;
+import com.commerce.product.api.mapper.CategoryMapper;
+import com.commerce.product.application.usecase.CreateCategoryRequest;
+import com.commerce.product.application.usecase.CreateCategoryResponse;
+import com.commerce.product.application.usecase.CreateCategoryUseCase;
+import com.commerce.product.domain.exception.InvalidCategoryHierarchyException;
+import com.commerce.product.domain.exception.InvalidCategoryLevelException;
+import com.commerce.product.domain.exception.InvalidCategoryNameException;
+import com.commerce.product.domain.exception.MaxCategoryDepthException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Category", description = "카테고리 관리 API")
+@RestController
+@RequestMapping("/api/categories")
+@RequiredArgsConstructor
+public class CategoryController {
+    
+    private final CreateCategoryUseCase createCategoryUseCase;
+    private final CategoryMapper categoryMapper;
+    
+    @Operation(summary = "카테고리 생성", description = "새로운 카테고리를 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "카테고리 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 카테고리 이름, 레벨, 계층 구조)"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping
+    public ResponseEntity<CategoryResponse> createCategory(
+            @Valid @RequestBody CreateCategoryApiRequest request) {
+        
+        CreateCategoryRequest useCaseRequest = categoryMapper.toCreateCategoryRequest(request);
+        CreateCategoryResponse useCaseResponse = createCategoryUseCase.execute(useCaseRequest);
+        CategoryResponse response = categoryMapper.toCategoryResponse(useCaseResponse);
+        
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+    
+    @ExceptionHandler(InvalidCategoryNameException.class)
+    public ResponseEntity<String> handleInvalidCategoryNameException(InvalidCategoryNameException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
+    
+    @ExceptionHandler(InvalidCategoryLevelException.class)
+    public ResponseEntity<String> handleInvalidCategoryLevelException(InvalidCategoryLevelException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
+    
+    @ExceptionHandler(InvalidCategoryHierarchyException.class)
+    public ResponseEntity<String> handleInvalidCategoryHierarchyException(InvalidCategoryHierarchyException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
+    
+    @ExceptionHandler(MaxCategoryDepthException.class)
+    public ResponseEntity<String> handleMaxCategoryDepthException(MaxCategoryDepthException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
+}

--- a/bootstrap/product-api/src/main/java/com/commerce/product/api/adapter/in/web/dto/CategoryResponse.java
+++ b/bootstrap/product-api/src/main/java/com/commerce/product/api/adapter/in/web/dto/CategoryResponse.java
@@ -1,0 +1,36 @@
+package com.commerce.product.api.adapter.in.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "카테고리 응답")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryResponse {
+    
+    @Schema(description = "카테고리 ID", example = "cat-001")
+    private String categoryId;
+    
+    @Schema(description = "카테고리 이름", example = "Electronics")
+    private String name;
+    
+    @Schema(description = "부모 카테고리 ID", example = "cat-000", nullable = true)
+    private String parentId;
+    
+    @Schema(description = "카테고리 레벨 (1: 대분류, 2: 중분류, 3: 소분류)", example = "1", minimum = "1", maximum = "3")
+    private int level;
+    
+    @Schema(description = "정렬 순서", example = "1", minimum = "0")
+    private int sortOrder;
+    
+    @Schema(description = "활성화 여부", example = "true")
+    private boolean active;
+    
+    @Schema(description = "전체 경로", example = "/Electronics/Smartphones")
+    private String fullPath;
+}

--- a/bootstrap/product-api/src/main/java/com/commerce/product/api/adapter/in/web/dto/CreateCategoryApiRequest.java
+++ b/bootstrap/product-api/src/main/java/com/commerce/product/api/adapter/in/web/dto/CreateCategoryApiRequest.java
@@ -1,0 +1,30 @@
+package com.commerce.product.api.adapter.in.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "카테고리 생성 요청")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateCategoryApiRequest {
+    
+    @Schema(description = "카테고리 이름", example = "Electronics", required = true)
+    @NotBlank(message = "Category name is required")
+    @Size(min = 1, max = 100, message = "Category name must be between 1 and 100 characters")
+    private String name;
+    
+    @Schema(description = "부모 카테고리 ID", example = "cat-001", nullable = true)
+    private String parentId;
+    
+    @Schema(description = "정렬 순서", example = "1", minimum = "0")
+    @Min(value = 0, message = "Sort order must be non-negative")
+    private int sortOrder;
+}

--- a/bootstrap/product-api/src/main/java/com/commerce/product/api/mapper/CategoryMapper.java
+++ b/bootstrap/product-api/src/main/java/com/commerce/product/api/mapper/CategoryMapper.java
@@ -1,0 +1,31 @@
+package com.commerce.product.api.mapper;
+
+import com.commerce.product.api.adapter.in.web.dto.CategoryResponse;
+import com.commerce.product.api.adapter.in.web.dto.CreateCategoryApiRequest;
+import com.commerce.product.application.usecase.CreateCategoryRequest;
+import com.commerce.product.application.usecase.CreateCategoryResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CategoryMapper {
+    
+    public CreateCategoryRequest toCreateCategoryRequest(CreateCategoryApiRequest apiRequest) {
+        return CreateCategoryRequest.builder()
+                .name(apiRequest.getName())
+                .parentId(apiRequest.getParentId())
+                .sortOrder(apiRequest.getSortOrder())
+                .build();
+    }
+    
+    public CategoryResponse toCategoryResponse(CreateCategoryResponse useCaseResponse) {
+        return CategoryResponse.builder()
+                .categoryId(useCaseResponse.getCategoryId())
+                .name(useCaseResponse.getName())
+                .parentId(useCaseResponse.getParentId())
+                .level(useCaseResponse.getLevel())
+                .sortOrder(useCaseResponse.getSortOrder())
+                .active(useCaseResponse.isActive())
+                .fullPath(useCaseResponse.getFullPath())
+                .build();
+    }
+}

--- a/bootstrap/product-api/src/test/java/com/commerce/product/api/adapter/in/web/CategoryControllerTest.java
+++ b/bootstrap/product-api/src/test/java/com/commerce/product/api/adapter/in/web/CategoryControllerTest.java
@@ -1,0 +1,189 @@
+package com.commerce.product.api.adapter.in.web;
+
+import com.commerce.product.api.adapter.in.web.dto.CreateCategoryApiRequest;
+import com.commerce.product.api.adapter.in.web.dto.CategoryResponse;
+import com.commerce.product.api.mapper.CategoryMapper;
+import com.commerce.product.application.usecase.CreateCategoryUseCase;
+import com.commerce.product.application.usecase.CreateCategoryRequest;
+import com.commerce.product.application.usecase.CreateCategoryResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryControllerTest {
+
+    private MockMvc mockMvc;
+    
+    @Mock
+    private CreateCategoryUseCase createCategoryUseCase;
+    
+    @Mock
+    private CategoryMapper categoryMapper;
+    
+    @InjectMocks
+    private CategoryController categoryController;
+    
+    private ObjectMapper objectMapper;
+    
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(categoryController)
+                .build();
+        objectMapper = new ObjectMapper();
+    }
+    
+    @Test
+    void createCategory_ShouldReturnCreatedCategory() throws Exception {
+        // Given
+        CreateCategoryApiRequest apiRequest = CreateCategoryApiRequest.builder()
+                .name("Electronics")
+                .parentId(null)
+                .sortOrder(1)
+                .build();
+                
+        CreateCategoryRequest useCaseRequest = CreateCategoryRequest.builder()
+                .name("Electronics")
+                .parentId(null)
+                .sortOrder(1)
+                .build();
+                
+        CreateCategoryResponse useCaseResponse = CreateCategoryResponse.builder()
+                .categoryId("cat-001")
+                .name("Electronics")
+                .parentId(null)
+                .level(1)
+                .sortOrder(1)
+                .isActive(true)
+                .fullPath("/Electronics")
+                .build();
+                
+        CategoryResponse apiResponse = CategoryResponse.builder()
+                .categoryId("cat-001")
+                .name("Electronics")
+                .parentId(null)
+                .level(1)
+                .sortOrder(1)
+                .active(true)
+                .fullPath("/Electronics")
+                .build();
+                
+        given(categoryMapper.toCreateCategoryRequest(any(CreateCategoryApiRequest.class)))
+                .willReturn(useCaseRequest);
+        given(createCategoryUseCase.execute(any(CreateCategoryRequest.class)))
+                .willReturn(useCaseResponse);
+        given(categoryMapper.toCategoryResponse(any(CreateCategoryResponse.class)))
+                .willReturn(apiResponse);
+                
+        // When & Then
+        mockMvc.perform(post("/api/categories")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(apiRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.categoryId").value("cat-001"))
+                .andExpect(jsonPath("$.name").value("Electronics"))
+                .andExpect(jsonPath("$.level").value(1))
+                .andExpect(jsonPath("$.active").value(true))
+                .andExpect(jsonPath("$.fullPath").value("/Electronics"));
+    }
+    
+    @Test
+    void createCategory_WithParent_ShouldReturnCreatedSubCategory() throws Exception {
+        // Given
+        CreateCategoryApiRequest apiRequest = CreateCategoryApiRequest.builder()
+                .name("Smartphones")
+                .parentId("cat-001")
+                .sortOrder(1)
+                .build();
+                
+        CreateCategoryRequest useCaseRequest = CreateCategoryRequest.builder()
+                .name("Smartphones")
+                .parentId("cat-001")
+                .sortOrder(1)
+                .build();
+                
+        CreateCategoryResponse useCaseResponse = CreateCategoryResponse.builder()
+                .categoryId("cat-002")
+                .name("Smartphones")
+                .parentId("cat-001")
+                .level(2)
+                .sortOrder(1)
+                .isActive(true)
+                .fullPath("/Electronics/Smartphones")
+                .build();
+                
+        CategoryResponse apiResponse = CategoryResponse.builder()
+                .categoryId("cat-002")
+                .name("Smartphones")
+                .parentId("cat-001")
+                .level(2)
+                .sortOrder(1)
+                .active(true)
+                .fullPath("/Electronics/Smartphones")
+                .build();
+                
+        given(categoryMapper.toCreateCategoryRequest(any(CreateCategoryApiRequest.class)))
+                .willReturn(useCaseRequest);
+        given(createCategoryUseCase.execute(any(CreateCategoryRequest.class)))
+                .willReturn(useCaseResponse);
+        given(categoryMapper.toCategoryResponse(any(CreateCategoryResponse.class)))
+                .willReturn(apiResponse);
+                
+        // When & Then
+        mockMvc.perform(post("/api/categories")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(apiRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.categoryId").value("cat-002"))
+                .andExpect(jsonPath("$.name").value("Smartphones"))
+                .andExpect(jsonPath("$.parentId").value("cat-001"))
+                .andExpect(jsonPath("$.level").value(2))
+                .andExpect(jsonPath("$.fullPath").value("/Electronics/Smartphones"));
+    }
+    
+    @Test
+    void createCategory_WithInvalidName_ShouldReturnBadRequest() throws Exception {
+        // Given
+        CreateCategoryApiRequest apiRequest = CreateCategoryApiRequest.builder()
+                .name("")
+                .parentId(null)
+                .sortOrder(1)
+                .build();
+                
+        // When & Then
+        mockMvc.perform(post("/api/categories")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(apiRequest)))
+                .andExpect(status().isBadRequest());
+    }
+    
+    @Test
+    void createCategory_WithNegativeSortOrder_ShouldReturnBadRequest() throws Exception {
+        // Given
+        CreateCategoryApiRequest apiRequest = CreateCategoryApiRequest.builder()
+                .name("Electronics")
+                .parentId(null)
+                .sortOrder(-1)
+                .build();
+                
+        // When & Then
+        mockMvc.perform(post("/api/categories")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(apiRequest)))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -183,7 +183,7 @@ Redis 기반 캐싱
 - [x] DELETE /api/inventory/reservations/{id} ✅ 구현 완료 (2025-09-25)
 
 #### 10.3 Category API
-- [ ] POST /api/categories
+- [x] POST /api/categories ✅ 구현 완료 (2025-09-26)
 - [ ] GET /api/categories/tree
 - [ ] GET /api/categories/{id}/products
 - [ ] PATCH /api/products/{id} (카테고리 할당을 위한 부분 업데이트)


### PR DESCRIPTION
## Summary
- CategoryController 생성 및 POST /api/categories 엔드포인트 구현
- TDD 방식으로 테스트 작성 후 구현 완료
- 모든 테스트 통과 및 빌드 성공

## 구현 내용
### 1. CategoryController 생성
- POST /api/categories 엔드포인트 구현
- 카테고리 생성 기능 제공
- 적절한 예외 처리 및 HTTP 상태 코드 반환

### 2. DTO 클래스 구현
- CreateCategoryApiRequest: API 요청 DTO
- CategoryResponse: API 응답 DTO
- CategoryMapper: DTO와 도메인 객체 간 매핑

### 3. 테스트 작성
- CategoryControllerTest 작성 (TDD)
- 정상 케이스 및 예외 케이스 모두 테스트
- 모든 테스트 통과

## Test Results
- ✅ createCategory_ShouldReturnCreatedCategory
- ✅ createCategory_WithParent_ShouldReturnCreatedSubCategory  
- ✅ createCategory_WithInvalidName_ShouldReturnBadRequest
- ✅ createCategory_WithNegativeSortOrder_ShouldReturnBadRequest

## 체크리스트
- [x] 코드 구현 완료
- [x] 단위 테스트 작성 및 통과
- [x] 빌드 성공
- [x] IMPLEMENTATION_PLAN.md 업데이트

Closes #87

🤖 Generated with [Claude Code](https://claude.ai/code)